### PR TITLE
Fixup the selector for etc rules.d file

### DIFF
--- a/QDMA/linux-kernel/etc/30-qdma.rules
+++ b/QDMA/linux-kernel/etc/30-qdma.rules
@@ -1,3 +1,3 @@
-KERNEL=="qdma[0-4]-MM-[0-9]*", MODE="0666"
-KERNEL=="qdma[0-4]-ST-[0-9]*", MODE="0666"
+KERNEL=="qdma*-MM-[0-9]*", MODE="0666"
+KERNEL=="qdma*-ST-[0-9]*", MODE="0666"
 


### PR DESCRIPTION
The previous selector doesn't match the typical `qdma01000-MM-0` that is mapped since it expects a single number to appear after `qdma`.