### PR TITLE
Null terminate a few strings in the driver

### DIFF
--- a/QDMA/linux-kernel/drv/nl.c
+++ b/QDMA/linux-kernel/drv/nl.c
@@ -977,7 +977,7 @@ static int xnl_q_start(struct sk_buff *skb2, struct genl_info *info)
 {
 	struct xlnx_pci_dev *xpdev;
 	struct qdma_queue_conf qconf;
-	char buf[XNL_RESP_BUFLEN_MIN];
+	char buf[XNL_RESP_BUFLEN_MIN] = {'\0'};
 	struct xlnx_qdata *qdata;
 	int rv = 0;
 	unsigned char is_qp;

--- a/QDMA/linux-kernel/drv/qdma_mod.c
+++ b/QDMA/linux-kernel/drv/qdma_mod.c
@@ -1654,7 +1654,7 @@ static void nl_work_handler_q_start(struct work_struct *work)
 						work);
 	struct xlnx_pci_dev *xpdev = nl_work->xpdev;
 	struct xlnx_nl_work_q_ctrl *qctrl = &nl_work->qctrl;
-	char ebuf[XNL_EBUFLEN];
+	char ebuf[XNL_EBUFLEN] = {'\0'};
 	unsigned int qidx = qctrl->qidx;
 	u8 is_qp = qctrl->is_qp;
 	u8 c2h = qctrl->is_c2h;

--- a/QDMA/linux-kernel/libqdma/libqdma_export.c
+++ b/QDMA/linux-kernel/libqdma/libqdma_export.c
@@ -774,7 +774,9 @@ handle_truncation:
  * @param[in]	id:		existing queue id
  * @param[in]	qconf:		queue configuration parameters
  * @param[in]	buflen:		length of the input buffer
- * @param[out]	buf:		message buffer
+ * @param[out]	buf:		message buffer, where the error message should
+ *                              be appended. This buffer needs to be null
+ *                              terminated.
  *
  * @return	0: success
  * @return	<0: error
@@ -801,7 +803,7 @@ int qdma_queue_reconfig(unsigned long dev_hndl, unsigned long id,
 		if (buf && buflen) {
 			int l = strlen(buf);
 
-			l += sprintf(buf + l,
+			l += snprintf(buf + l, buflen - l,
 				"%s invalid state, q_state %d.\n",
 				descq->conf.name, descq->q_state);
 			buf[l] = '\0';
@@ -1129,7 +1131,9 @@ handle_truncation:
  * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
  * @param[in]	id:		queue index
  * @param[in]	buflen:		length of the input buffer
- * @param[out]	buf:		message buffer
+ * @param[out]	buf:		message buffer, where the error message should
+ *                              be appended. This buffer needs to be null
+ *                              terminated.
  *
  * @return	0: success
  * @return	<0: error
@@ -1153,10 +1157,8 @@ int qdma_queue_start(unsigned long dev_hndl, unsigned long id,
 			descq->conf.name, descq->qidx_hw);
 		if (buf && buflen) {
 			int l = strlen(buf);
-
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				"%s config failed.\n", descq->conf.name);
-			buf[l] = '\0';
 		}
 		goto free_resource;
 	}
@@ -1170,8 +1172,7 @@ int qdma_queue_start(unsigned long dev_hndl, unsigned long id,
 			descq->conf.name, descq->q_state);
 		if (buf && buflen) {
 			int l = strlen(buf);
-
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				"%s invalid state, q_state %d.\n",
 				descq->conf.name, descq->q_state);
 		}
@@ -1184,8 +1185,7 @@ int qdma_queue_start(unsigned long dev_hndl, unsigned long id,
 	if (rv < 0) {
 		if (buf && buflen) {
 			int l = strlen(buf);
-
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				"%s alloc resource failed.\n",
 				descq->conf.name);
 				buf[l] = '\0';
@@ -1210,7 +1210,7 @@ int qdma_queue_start(unsigned long dev_hndl, unsigned long id,
 	}
 
 	/** Interrupt mode */
-	if (descq->xdev->num_vecs) {	
+	if (descq->xdev->num_vecs) {
 		unsigned long flags;
 
 		spin_lock_irqsave(&descq->xdev->lock, flags);
@@ -1250,7 +1250,9 @@ free_resource:
  * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
  * @param[in]	id:		queue index
  * @param[in]	buflen:		length of the input buffer
- * @param[out]	buf:		message buffer
+ * @param[out]	buf:		message buffer, where the error message should
+ *                              be appended. This buffer needs to be null
+ *                              terminated.
  *
  * @return	0: success
  * @return	<0: error
@@ -1274,7 +1276,7 @@ int qdma_queue_prog_stm(unsigned long dev_hndl, unsigned long id,
 		if (buf && buflen) {
 			int l = strlen(buf);
 
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				      "%s Skipping STM prog for MM queue.\n",
 				      descq->conf.name);
 		}
@@ -1287,7 +1289,7 @@ int qdma_queue_prog_stm(unsigned long dev_hndl, unsigned long id,
 		if (buf && buflen) {
 			int l = strlen(buf);
 
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				      "%s No STM present; stm_rev %d.\n",
 				      descq->conf.name, xdev->stm_rev);
 		}
@@ -1304,7 +1306,7 @@ int qdma_queue_prog_stm(unsigned long dev_hndl, unsigned long id,
 		if (buf && buflen) {
 			int l = strlen(buf);
 
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				      "%s invalid state, q_state %d.\n",
 				      descq->conf.name, descq->q_state);
 		}
@@ -1322,10 +1324,9 @@ int qdma_queue_prog_stm(unsigned long dev_hndl, unsigned long id,
 		if (buf && buflen) {
 			int l = strlen(buf);
 
-			l += snprintf(buf + l, buflen,
+			l += snprintf(buf + l, buflen - l,
 				      "%s prog. STM failed.\n",
 				      descq->conf.name);
-			buf[l] = '\0';
 		}
 		return rv;
 	}

--- a/QDMA/linux-kernel/libqdma/libqdma_export.h
+++ b/QDMA/linux-kernel/libqdma/libqdma_export.h
@@ -806,16 +806,19 @@ int qdma_queue_add(unsigned long dev_hndl, struct qdma_queue_conf *qconf,
 
 /*****************************************************************************/
 /**
- * qdma_queue_reconfig() - reconfigure the queue
+ * qdma_queue_reconfig() - reconfigure the existing queue with
+ *							modified configuration
  *
- * @param[in]	dev_hndl:	qdma device handle
- * @param[in]	id:		queue index
- * @param[in]	qconf:		queue configuration
+ * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
+ * @param[in]	id:		existing queue id
+ * @param[in]	qconf:		queue configuration parameters
  * @param[in]	buflen:		length of the input buffer
- * @param[out]	buf:		message buffer
+ * @param[out]	buf:		message buffer, where the error message should
+ *                              be appended. This buffer needs to be null
+ *                              terminated.
  *
  * @return	0: success
- * @return	<0: failure
+ * @return	<0: error
  *****************************************************************************/
 int qdma_queue_reconfig(unsigned long dev_hndl, unsigned long id,
 			struct qdma_queue_conf *qconf, char *buf, int buflen);
@@ -825,9 +828,11 @@ int qdma_queue_reconfig(unsigned long dev_hndl, unsigned long id,
  * qdma_queue_start() - start a queue (i.e, online, ready for dma)
  *
  * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
- * @param[in]	id:		the opaque qhndl
+ * @param[in]	id:		queue index
  * @param[in]	buflen:		length of the input buffer
- * @param[out]	buf:		message buffer
+ * @param[out]	buf:		message buffer, where the error message should
+ *                              be appended. This buffer needs to be null
+ *                              terminated.
  *
  * @return	0: success
  * @return	<0: error
@@ -852,15 +857,17 @@ int qdma_queue_stop(unsigned long dev_hndl, unsigned long id, char *buf,
 
 /*****************************************************************************/
 /**
- *  * qdma_queue_prog_stm() - Program STM for queue (context, map, etc)
- *   *
- * @param[in]   dev_hndl:       dev_hndl returned from qdma_device_open()
- * @param[in]   id:             queue index
- * @param[in]   buflen:         length of the input buffer
- * @param[out]  buf:            message buffer
+ * qdma_queue_prog_stm() - Program STM for queue (context, map, etc)
  *
- * @return      0: success
- * @return      <0: error
+ * @param[in]	dev_hndl:	dev_hndl returned from qdma_device_open()
+ * @param[in]	id:		queue index
+ * @param[in]	buflen:		length of the input buffer
+ * @param[out]	buf:		message buffer, where the error message should
+ *                              be appended. This buffer needs to be null
+ *                              terminated.
+ *
+ * @return	0: success
+ * @return	<0: error
  *****************************************************************************/
 int qdma_queue_prog_stm(unsigned long dev_hndl, unsigned long id, char *buf,
 			int buflen);

--- a/QDMA/linux-kernel/tools/dmautils.c
+++ b/QDMA/linux-kernel/tools/dmautils.c
@@ -1059,7 +1059,9 @@ static void *io_thread(void *argp)
 		}
 		ret = io_queue_init(max_io, &node->ctxt);
 		if (ret != 0) {
-			printf("Error: io_setup error %d on %u\n", ret, _info->thread_id);
+			char * err_s = strerror(-ret);
+			printf("Error: io_setup error %s (%d) on thread %u\n",
+				err_s, ret, _info->thread_id);
 			dma_free(&ctxhandle, node);
 			sched_yield();
 			continue;


### PR DESCRIPTION
The driver gives uninitiated memory as an input string buffer where text is appended.

A call to strlen is first made, which has the potential of overrrunning the whole string.