### PR TITLE
Fix building for Linux 5.0 and newer

### DIFF
--- a/XDMA/linux-kernel/libxdma/libxdma.c
+++ b/XDMA/linux-kernel/libxdma/libxdma.c
@@ -715,7 +715,10 @@ static struct xdma_transfer *engine_start(struct xdma_engine *engine)
 
 	dbg_tfr("ioread32(0x%p) (dummy read flushes writes).\n",
 		&engine->regs->status);
+
+#if KERNEL_VERSION(5, 1, 0) >= LINUX_VERSION_CODE
 	mmiowb();
+#endif
 
 	rv = engine_start_mode_config(engine);
 	if (rv < 0) {

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -24,6 +24,12 @@
 #include "xdma_cdev.h"
 #include "cdev_ctrl.h"
 
+#if KERNEL_VERSION(5, 0, 0) <= LINUX_VERSION_CODE
+#define xlx_access_ok(X,Y,Z) access_ok(Y,Z)
+#else
+#define xlx_access_ok(X,Y,Z) access_ok(X,Y,Z)
+#endif
+
 /*
  * character device file operations for control bus (through control bridge)
  */
@@ -144,10 +150,10 @@ long char_ctrl_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	}
 
 	if (_IOC_DIR(cmd) & _IOC_READ)
-		result = !access_ok(VERIFY_WRITE, (void __user *)arg,
+		result = !xlx_access_ok(VERIFY_WRITE, (void __user *)arg,
 				_IOC_SIZE(cmd));
 	else if (_IOC_DIR(cmd) & _IOC_WRITE)
-		result =  !access_ok(VERIFY_READ, (void __user *)arg,
+		result =  !xlx_access_ok(VERIFY_READ, (void __user *)arg,
 				_IOC_SIZE(cmd));
 
 	if (result) {

--- a/XDMA/linux-kernel/xdma/cdev_xvc.c
+++ b/XDMA/linux-kernel/xdma/cdev_xvc.c
@@ -213,7 +213,9 @@ static long xvc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 		pr_info("copy back tdo_buf failed: %d/%u.\n", rv, total_bytes);
 
 unlock:
+#if KERNEL_VERSION(5, 1, 0) >= LINUX_VERSION_CODE
 	mmiowb();
+#endif
 	spin_unlock(&xcdev->lock);
 
 cleanup:


### PR DESCRIPTION
As the title says.

Mainly, there's now a wrapper for simple wait queue interface and access_ok macro that evolved in 4.19 and 5.0 respectively.