### PR TITLE
Fix a Linux crash when pci_msix_vec_count() returns -EINVAL

### DIFF
--- a/QDMA/linux-kernel/libqdma/qdma_intr.c
+++ b/QDMA/linux-kernel/libqdma/qdma_intr.c
@@ -532,7 +532,7 @@ int intr_setup(struct xlnx_dma_dev *xdev)
 	pr_debug("dev %s, xdev->num_vecs = %d\n",
 			dev_name(&xdev->conf.pdev->dev), xdev->num_vecs);
 
-	if (num_vecs == 0) {
+	if (num_vecs <= 0) {
 		pr_warn("MSI-X not supported, running in polled mode\n");
 		return 0;
 	}


### PR DESCRIPTION
Also described in https://github.com/Xilinx/dma_ip_drivers/issues/45