### PR TITLE
Fixes a design error revealed by running on aarch64

### DIFF
--- a/XDMA/linux-kernel/libxdma/libxdma.h
+++ b/XDMA/linux-kernel/libxdma/libxdma.h
@@ -511,7 +511,7 @@ struct xdma_engine {
 	u32 irq_bitmask;		/* IRQ bit mask for this engine */
 	struct work_struct work;	/* Work queue for interrupt handling */
 
-	spinlock_t desc_lock;		/* protects concurrent access */
+	struct mutex desc_lock;		/* protects concurrent access */
 	dma_addr_t desc_bus;
 	struct xdma_desc *desc;
 	int desc_idx;			/* current descriptor index */


### PR DESCRIPTION
Simply put, you cannot call wait_event_interruptible_timeout while
holding a spin_lock. The reason the driver got away with this on
x86 is because the hardware is somehow fast enough so that the
condition is never false and hence no scheduling ever needs to
occur.