### PR TITLE
Remove comment about qdma_user_isr_enable() which does not exist

### DIFF
--- a/QDMA/linux-kernel/libqdma/libqdma_export.h
+++ b/QDMA/linux-kernel/libqdma/libqdma_export.h
@@ -765,8 +765,6 @@ void intr_legacy_init(void);
  * qdma_device_open()- read the pci bars and configure the fpga
  * This API should be called from probe()
  *
- * User interrupt will not be enabled until qdma_user_isr_enable() is called
- *
  * @mod_name:	the module name, used for request_irq
  * @conf:		device configuration
  * @dev_hndl:	an opaque handle for libqdma to identify the device


### PR DESCRIPTION
The function qdma_user_isr_enable() currently does not exist.
About the user IRQs, there are no exported functions: users can only set the
user_msix_qvec_max and fp_user_isr_handler fields in qdma_dev_conf structure.
The value specified in the field "user_msix_qvec_max" is not registered to QDMA IP (no QDMA internal registers are involved): it is only used to setup new IRQs (with PCI functions request_irq/request_threaded_irq). Maybe the functionalities of qdma_user_isr_enable() are still required to interact with the QDMA IP about user IRQs but the source code is missing.
Unfortunately it is not clear what is the right procedure to enable the user IRQs (in my tests they don't work): it would be good to replace the comment with another one referable to the actual libqdma version. 