### PR TITLE
Various fixes for the build procedure of QDMA apps

### DIFF
--- a/QDMA/linux-kernel/apps/Makefile
+++ b/QDMA/linux-kernel/apps/Makefile
@@ -1,6 +1,5 @@
 SHELL = /bin/bash
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += $(EXTRA_FLAGS)
 

--- a/QDMA/linux-kernel/apps/dma-ctl/Makefile
+++ b/QDMA/linux-kernel/apps/dma-ctl/Makefile
@@ -1,6 +1,5 @@
 SHELL = /bin/bash
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include -I../dma-utils
 CFLAGS += $(EXTRA_FLAGS)
@@ -17,7 +16,7 @@ endif
 all: clean dma-ctl
 
 dma-ctl: $(DMA-CTL_OBJS)
-	$(CC) -pthread -lrt $^ -o $(DMA-CTL) -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) $(LDFLAGS) -pthread $^ -o $(DMA-CTL) -lrt -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
 	
 %.o: %.c
 	$(CC) $(CFLAGS) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE -D_AIO_AIX_SOURCE

--- a/QDMA/linux-kernel/apps/dma-from-device/Makefile
+++ b/QDMA/linux-kernel/apps/dma-from-device/Makefile
@@ -1,6 +1,5 @@
 CC ?= gcc
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include -I../dma-utils
 CFLAGS += $(EXTRA_FLAGS)
@@ -17,7 +16,7 @@ endif
 all: clean dma-from-device
 
 dma-from-device: $(DMA-FROM-DEVICE_OBJS)
-	$(CC) -lrt -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) $(LDFLAGS) -pthread -o $@ $< -lrt -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE -D_AIO_AIX_SOURCE

--- a/QDMA/linux-kernel/apps/dma-latency/Makefile
+++ b/QDMA/linux-kernel/apps/dma-latency/Makefile
@@ -1,6 +1,5 @@
 CC ?= gcc
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include -I../dma-utils
 CFLAGS += $(EXTRA_FLAGS)
@@ -17,7 +16,7 @@ endif
 all: clean dma-latency
 
 dma-latency: $(DMA-LAT_OBJS)
-	$(CC) -pthread -lrt -o $@ $^ -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) $(LDFLAGS) -pthread -o $@ $^ -lrt -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE -D_AIO_AIX_SOURCE

--- a/QDMA/linux-kernel/apps/dma-latency/dmalat.c
+++ b/QDMA/linux-kernel/apps/dma-latency/dmalat.c
@@ -22,7 +22,7 @@
 #include <errno.h>
 #include <error.h>
 #include <sys/ioctl.h>
-#include </usr/include/pthread.h>
+#include <pthread.h>
 #include "dmautils.h"
 #include "qdma_nl.h"
 

--- a/QDMA/linux-kernel/apps/dma-perf/Makefile
+++ b/QDMA/linux-kernel/apps/dma-perf/Makefile
@@ -1,6 +1,5 @@
 CC ?= gcc
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include -I../dma-utils
 CFLAGS += $(EXTRA_FLAGS)
@@ -17,7 +16,7 @@ endif
 all: clean dma-perf
 
 dma-perf: $(DMA-PERF_OBJS)
-	$(CC) -pthread -lrt -o $@ $^ -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) $(LDFLAGS) -pthread -o $@ $^ -lrt -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE -D_AIO_AIX_SOURCE

--- a/QDMA/linux-kernel/apps/dma-perf/dmaperf.c
+++ b/QDMA/linux-kernel/apps/dma-perf/dmaperf.c
@@ -32,7 +32,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
-#include </usr/include/pthread.h>
+#include <pthread.h>
 #include <libaio.h>
 #include <sys/sysinfo.h>
 #include "dmautils.h"

--- a/QDMA/linux-kernel/apps/dma-to-device/Makefile
+++ b/QDMA/linux-kernel/apps/dma-to-device/Makefile
@@ -1,6 +1,5 @@
 CC ?= gcc
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include -I../dma-utils
 CFLAGS += $(EXTRA_FLAGS)
@@ -17,7 +16,7 @@ endif
 all: clean dma-to-device
 
 dma-to-device: $(DMA-TO-DEVICE_OBJS)
-	$(CC) -lrt -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) $(LDFLAGS) -o $@ $< -lrt -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE -D_AIO_AIX_SOURCE

--- a/QDMA/linux-kernel/apps/dma-utils/Makefile
+++ b/QDMA/linux-kernel/apps/dma-utils/Makefile
@@ -1,6 +1,5 @@
 CC ?= gcc
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include
 CFLAGS += $(EXTRA_FLAGS)

--- a/QDMA/linux-kernel/apps/dma-utils/dmaxfer.c
+++ b/QDMA/linux-kernel/apps/dma-utils/dmaxfer.c
@@ -30,7 +30,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <sys/ioctl.h>
-#include </usr/include/pthread.h>
+#include <pthread.h>
 #include <libaio.h>
 #include <sys/sysinfo.h>
 #include <sys/uio.h>

--- a/QDMA/linux-kernel/apps/dma-xfer/Makefile
+++ b/QDMA/linux-kernel/apps/dma-xfer/Makefile
@@ -1,6 +1,5 @@
 CC ?= gcc
 
-CFLAGS += -g
 #CFLAGS += -O2 -fno-inline -Wall -Wstrict-prototypes
 CFLAGS += -I. -I../include -I../dma-utils
 CFLAGS += $(EXTRA_FLAGS)
@@ -17,7 +16,7 @@ endif
 all: clean dma-xfer
 
 dma-xfer: $(DMA-XFER_OBJS)
-	$(CC) -pthread -lrt  $^ -o $(DMA-XFER) -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) $(LDFLAGS) -pthread $^ -o $(DMA-XFER) -lrt -laio -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
 
 %.o: %.c
 	$(CC) $(CFLAGS) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE -D_AIO_AIX_SOURCE


### PR DESCRIPTION


* Removes the mandatory debugging information
* Adds LDFLAGS to the linking step
* moves `-lrt` until after the sources are specified. For some reason this trips up certain versions of gcc
* Use compiler `pthread.h` instead of `/usr/include/pthread.h`