### PR TITLE
Fix warnings

### DIFF
--- a/XDMA/linux-kernel/libxdma/libxdma.c
+++ b/XDMA/linux-kernel/libxdma/libxdma.c
@@ -3074,7 +3074,7 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 
 	/* remember SG DMA direction */
 	engine->dir = dir;
-	sprintf(engine->name, "%d-%s%d-%s", xdev->idx,
+	snprintf(engine->name, sizeof(engine->name), "%d-%s%d-%s", xdev->idx,
 		(dir == DMA_TO_DEVICE) ? "H2C" : "C2H", channel,
 		engine->streaming ? "ST" : "MM");
 

--- a/XDMA/linux-kernel/libxdma/libxdma.h
+++ b/XDMA/linux-kernel/libxdma/libxdma.h
@@ -475,7 +475,7 @@ struct xdma_request_cb {
 struct xdma_engine {
 	unsigned long magic;	/* structure ID for sanity checks */
 	struct xdma_dev *xdev;	/* parent device */
-	char name[5];		/* name of this engine */
+	char name[16];		/* name of this engine */
 	int version;		/* version of this engine */
 	//dev_t cdevno;		/* character device major:minor */
 	//struct cdev cdev;	/* character device (embedded struct) */

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -351,7 +351,7 @@ static struct pci_driver pci_driver = {
 	.err_handler = &xdma_err_handler,
 };
 
-static int __init xdma_mod_init(void)
+static int xdma_mod_init(void)
 {
 	int rv;
 
@@ -369,7 +369,7 @@ static int __init xdma_mod_init(void)
 	return pci_register_driver(&pci_driver);
 }
 
-static void __exit xdma_mod_exit(void)
+static void xdma_mod_exit(void)
 {
 	/* unregister this driver from the PCI bus driver */
 	dbg_init("pci_unregister_driver.\n");


### PR DESCRIPTION
Fix warnings when building on centos7 with devtoolset-9.
Use snprintf and increase character array size to 16.
Remove attributes from init/exit functions in module.
