### PR TITLE
Minor fixes to address fortify source errors in QDMA applications

### DIFF
--- a/QDMA/linux-kernel/apps/dma-utils/dmactl.c
+++ b/QDMA/linux-kernel/apps/dma-utils/dmactl.c
@@ -176,11 +176,13 @@ static int xnl_connect(struct xnl_cb *cb, int vf, void (*log_err)(const char *))
 
 	if (vf) {
         	attr->nla_len = strlen(XNL_NAME_VF) + 1 + NLA_HDRLEN;
-        	strcpy((char *)(attr + 1), XNL_NAME_VF);
+            // Use memcpy to avoid a fortify source error
+        	memcpy((char *)(attr + 1), XNL_NAME_VF, strlen(XNL_NAME_VF) + 1);
 
 	} else {
         	attr->nla_len = strlen(XNL_NAME_PF) + 1 + NLA_HDRLEN;
-        	strcpy((char *)(attr + 1), XNL_NAME_PF);
+            // Use memcpy to avoid a fortify source error
+        	memcpy((char *)(attr + 1), XNL_NAME_PF, strlen(XNL_NAME_PF) + 1);
 	}
         hdr->n.nlmsg_len += NLMSG_ALIGN(attr->nla_len);
 

--- a/QDMA/linux-kernel/apps/dma-utils/dmactl_reg.c
+++ b/QDMA/linux-kernel/apps/dma-utils/dmactl_reg.c
@@ -204,7 +204,8 @@ static void print_repeated_reg(uint32_t *bar, struct xreg_info *xreg,
 
 	for (i = start; i < end; i++) {
 		uint32_t addr = xreg->addr + (i * step);
-		char name[40];
+        // Name must be bigger than xreg->name + 10 characters
+		char name[128];
 		sprintf(name, "%s_%d",
 				xreg->name, i);
 

--- a/QDMA/linux-kernel/apps/dma-utils/dmaxfer.c
+++ b/QDMA/linux-kernel/apps/dma-utils/dmaxfer.c
@@ -773,6 +773,7 @@ int dmaxfer_perf_run(struct dmaxfer_io_info *list,
 	int shmid;
 	int base_pid;
 	int *child_pid_lst;
+	int rv;
 
 #if DATA_VALIDATION
 	for (i = 0; i < 2*1024; i++)
@@ -787,7 +788,10 @@ int dmaxfer_perf_run(struct dmaxfer_io_info *list,
 
 	snprintf(aio_max_nr_cmd, 100, "echo %u > /proc/sys/fs/aio-max-nr",
 		 aio_max_nr);
-	system(aio_max_nr_cmd);
+	rv = system(aio_max_nr_cmd);
+	// Echo might return 1 if permission is denied.
+	if (rv != 0)
+		return -rv;
 
 	handle = (struct dmaxfer_perf_handle *)calloc(1, sizeof(struct dmaxfer_perf_handle));
 	if (!handle)


### PR DESCRIPTION
Many distributions are starting to fortify source for packaged applications.

This helps alleviate certain issues which would otherwise cause the system to exit from the application.