### PR TITLE
Fixes to device save/restore state

### DIFF
--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -222,6 +222,8 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	dev_set_drvdata(&pdev->dev, xpdev);
 
+	pci_save_state(pdev);
+
 	return 0;
 
 err_out:

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -295,6 +295,8 @@ static void xdma_error_resume(struct pci_dev *pdev)
 	struct xdma_pci_dev *xpdev = dev_get_drvdata(&pdev->dev);
 
 	pr_info("dev 0x%p,0x%p.\n", pdev, xpdev);
+	pci_restore_state(pdev);
+	pci_save_state(pdev);
 #if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE
 	pci_aer_clear_nonfatal_status(pdev);
 #else


### PR DESCRIPTION
It was observed that in case root port supports AER it might request a reset of the secondary bus. In this case devices on that bus need to restore its state to what it was before the reset in order to continue working.

This PR adds a call to save the device state at probe time. This state is then used during error recovery to configure the device back after its PCI(e) control registers have been wiped (i.e. due to bus reset).

Second commit adds the calls to restore/save device config to `xdma_error_resume()` callback. It was observed that the `xdma_slot_reset()` is not called by the recovery process. See also https://lore.kernel.org/linux-pci/0def63a9-9a9e-440c-6bd8-7fd8dfef5b63@ess.eu/.
