### PR TITLE
QDMA: linux-driver: fix QDMA_REG_GLBL_MDMA_CHANNEL bit masks

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_reg.h
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_reg.h
@@ -362,8 +362,8 @@ extern "C" {
 #define QDMA_OFFSET_GLBL2_PF_VF_BARLITE_EXT                 0x110
 #define QDMA_OFFSET_GLBL2_CHANNEL_INST                      0x114
 #define QDMA_OFFSET_GLBL2_CHANNEL_MDMA                      0x118
-#define     QDMA_GLBL2_ST_C2H_MASK                          BIT(16)
-#define     QDMA_GLBL2_ST_H2C_MASK                          BIT(17)
+#define     QDMA_GLBL2_ST_C2H_MASK                          BIT(17)
+#define     QDMA_GLBL2_ST_H2C_MASK                          BIT(16)
 #define     QDMA_GLBL2_MM_C2H_MASK                          BIT(8)
 #define     QDMA_GLBL2_MM_H2C_MASK                          BIT(0)
 #define QDMA_OFFSET_GLBL2_CHANNEL_STRM                      0x11C


### PR DESCRIPTION
From the QDMA 3.0 documentation (pg302), h2c_st is the 16th bit and c2h_st is the 17th bit of register QDMA_REG_GLBL_MDMA_CHANNEL.
So fix the bit masks associated to QDMA_REG_GLBL_MDMA_CHANNEL.