### PR TITLE
QDMA: linux-driver: read QDMA_REG_GLBL_STRM_CHANNEL to check DMA mode

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.h
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.h
@@ -590,7 +590,7 @@ enum qdma_reg_read_type {
  * enum qdma_reg_read_groups - Indicates reg read groups
  */
 enum qdma_reg_read_groups {
-	/** @QDMA_REG_READ_GROUP_1: Read the register from  0x000 to 0x288 */
+	/** @QDMA_REG_READ_GROUP_1: Read the register from  0x000 to 0x2C4 */
 	QDMA_REG_READ_GROUP_1,
 	/** @QDMA_REG_READ_GROUP_2: Read the register from 0x400 to 0xAFC */
 	QDMA_REG_READ_GROUP_2,

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
@@ -4152,7 +4152,7 @@ int qdma_get_device_attributes(void *dev_hndl,
 	dev_info->mm_cmpt_en  = FIELD_GET(QDMA_GLBL2_MM_CMPT_EN_MASK, reg_val);
 
 	/* ST/MM enabled? */
-	reg_val = qdma_reg_read(dev_hndl, QDMA_OFFSET_GLBL2_CHANNEL_MDMA);
+	reg_val = qdma_reg_read(dev_hndl, QDMA_OFFSET_GLBL2_CHANNEL_STRM);
 	dev_info->mm_en = (FIELD_GET(QDMA_GLBL2_MM_C2H_MASK, reg_val)
 			&& FIELD_GET(QDMA_GLBL2_MM_H2C_MASK, reg_val)) ? 1 : 0;
 	dev_info->st_en = (FIELD_GET(QDMA_GLBL2_ST_C2H_MASK, reg_val)

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
@@ -186,7 +186,7 @@ static struct xreg_info qdma_config_regs[] = {
 		0x27C, 1,  0, 0, 0, 0,
 		QDMA_MM_ST_MODE, QDMA_REG_READ_PF_VF, 0, NULL},
 	{"GLBL_INTERRUPT_CFG",
-		0x288, 1, 0, 0, 0, 0,
+		0x2C4, 1, 0, 0, 0, 0,
 		QDMA_MM_ST_MODE, QDMA_REG_READ_PF_VF, 0, NULL},
 
 	/* QDMA_TRQ_SEL_FMAP (0x00400 - 0x7FC) */


### PR DESCRIPTION
This patch is needed because reading QDMA_GLBL2_CHANNEL_MDMA (0x118)
register on QDMA 3.0 to check the DMA mode is wrong.
The right register to check is QDMA_GLBL2_CHANNEL_STRM (0x11C).

From pg302 (3.0), QDMA_GLBL2_CHANNEL_MDMA bits are documented as:
[17] c2h_st: A one indicates the C2H ST engine is QDMA;
[16] h2c_st: A one indicates the H2C ST engine is QDMA;
[8]  c2h_eng[0]: A one indicates the C2H ST engine is QDMA;
[9]  h2c_eng[0]: A one indicates the H2C ST engine is QDMA.

From pg302 (3.0), QDMA_GLBL2_CHANNEL_STRM bits are documented as:
[17] c2h_st: A one indicates it is a Stream mode dma engine;
[16] h2c_st): A one indicates it is a Stream mode dma engine;
[8]  c2h_eng[0]: A one indicates it is a Memory-Mapped mode dma engine;
[9]  h2c_eng[0]: A one indicates it is a Memory-Mapped mode DMA engine.