### PR TITLE
QDMA: linux-driver: fix GLBL_INTERRUPT_CFG offset

### DIFF
--- a/QDMA/linux-kernel/apps/include/xdev_regs.h
+++ b/QDMA/linux-kernel/apps/include/xdev_regs.h
@@ -74,7 +74,7 @@ static struct xreg_info qdma_config_regs[] = {
 	{"GLBL_TRQ_ERR_LOG",				0x26C, 0,  0, 0, 0,},
 	{"GLBL_DSC_DBG_DAT",				0x270, 2,  0, 0, 0,},
 	{"GLBL_DSC_ERR_LOG2",				0x27C, 0,  0, 0, 0,},
-	{"GLBL_INTERRUPT_CFG",				0x288, 0,  0, 0, 0,},
+	{"GLBL_INTERRUPT_CFG",				0x2C4, 0,  0, 0, 0,},
 
 	/* QDMA_TRQ_SEL_FMAP (0x00400 - 0x7FC) * TODO: max 256, display 4 for now */
 	{"TRQ_SEL_FMAP",				0x400, 4, 0, 0, 0,},

--- a/QDMA/linux-kernel/driver/include/xdev_regs.h
+++ b/QDMA/linux-kernel/driver/include/xdev_regs.h
@@ -81,7 +81,7 @@ static struct xreg_info qdma_config_regs[] = {
 	{"GLBL_TRQ_ERR_LOG",				0x26C, 0,  0, 0, 0,},
 	{"GLBL_DSC_DBG_DAT",				0x270, 2,  0, 0, 0,},
 	{"GLBL_DSC_ERR_LOG2",				0x27C, 0,  0, 0, 0,},
-	{"GLBL_INTERRUPT_CFG",				0x288, 0,  0, 0, 0,},
+	{"GLBL_INTERRUPT_CFG",				0x2C4, 0,  0, 0, 0,},
 
 	/* QDMA_TRQ_SEL_FMAP (0x00400 - 0x7FC) */
 	/* TODO: max 256, display 4 for now */

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.h
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.h
@@ -590,7 +590,7 @@ enum qdma_reg_read_type {
  * enum qdma_reg_read_groups - Indicates reg read groups
  */
 enum qdma_reg_read_groups {
-	/** @QDMA_REG_READ_GROUP_1: Read the register from  0x000 to 0x288 */
+	/** @QDMA_REG_READ_GROUP_1: Read the register from  0x000 to 0x2C4 */
 	QDMA_REG_READ_GROUP_1,
 	/** @QDMA_REG_READ_GROUP_2: Read the register from 0x400 to 0xAFC */
 	QDMA_REG_READ_GROUP_2,

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
@@ -186,7 +186,7 @@ static struct xreg_info qdma_config_regs[] = {
 		0x27C, 1,  0, 0, 0, 0,
 		QDMA_MM_ST_MODE, QDMA_REG_READ_PF_VF, 0, NULL},
 	{"GLBL_INTERRUPT_CFG",
-		0x288, 1, 0, 0, 0, 0,
+		0x2C4, 1, 0, 0, 0, 0,
 		QDMA_MM_ST_MODE, QDMA_REG_READ_PF_VF, 0, NULL},
 
 	/* QDMA_TRQ_SEL_FMAP (0x00400 - 0x7FC) */


### PR DESCRIPTION
The offset of register GLBL_INTERRUPT_CFG is 0x2C4.