### PR TITLE
save initial device state

### DIFF
--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -222,6 +222,8 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	dev_set_drvdata(&pdev->dev, xpdev);
 
+	pci_save_state(pdev);
+
 	return 0;
 
 err_out:


### PR DESCRIPTION
It was observed that in case root port supports AER it might request a reset of the secondary bus. In this case devices on that bus need to restore its state to what it was before the reset in order to continue working.

This PR adds a call to save the device state at probe time. This state is then used during error recovery to configure the device back after its PCI(e) control registers have been wiped (i.e. due to bus reset).

Tested on 5.11.0-rc3 with https://lore.kernel.org/linux-pci/20210104230300.1277180-1-kbusch@kernel.org/ applied.

Obsoletes PR #97.