### PR TITLE
Update xdma_mod.c

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -53,6 +53,12 @@
 #	define HAS_SWAKE_UP (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0))
 #endif
 
+#if defined(RHEL_RELEASE_CODE)
+#	define PCI_AER_NAMECHANGE (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(8, 3))
+#else
+#	define PCI_AER_NAMECHANGE (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 7, 0))
+#endif
+
 #if	HAS_SWAKE_UP
 #include <linux/swait.h>
 #endif

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -293,7 +293,8 @@ static void xdma_error_resume(struct pci_dev *pdev)
 	struct xdma_pci_dev *xpdev = dev_get_drvdata(&pdev->dev);
 
 	pr_info("dev 0x%p,0x%p.\n", pdev, xpdev);
-#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE
+#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE  || \
+    defined(RHEL_MAJOR) && RHEL_RELEASE_VERSION(8, 3) <= RHEL_RELEASE_CODE
 	pci_aer_clear_nonfatal_status(pdev);
 #else
 	pci_cleanup_aer_uncorrect_error_status(pdev);

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -293,12 +293,12 @@ static void xdma_error_resume(struct pci_dev *pdev)
 	struct xdma_pci_dev *xpdev = dev_get_drvdata(&pdev->dev);
 
 	pr_info("dev 0x%p,0x%p.\n", pdev, xpdev);
-#if KERNEL_VERSION(5, 7, 0) <= LINUX_VERSION_CODE  || \
-    defined(RHEL_MAJOR) && RHEL_RELEASE_VERSION(8, 3) <= RHEL_RELEASE_CODE
+#if PCI_AER_NAMECHANGE
 	pci_aer_clear_nonfatal_status(pdev);
 #else
 	pci_cleanup_aer_uncorrect_error_status(pdev);
 #endif
+
 }
 
 #if KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE


### PR DESCRIPTION
build on CentOS 8.3 will generate error:

XDMA/linux-kernel/xdma/xdma_mod.c:301:2: error: implicit declaration of function ??pci_cleanup_aer_uncorrect_error_status?? [-Werror=implicit-function-declaration]
  pci_cleanup_aer_uncorrect_error_status(pdev);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:316: /home/ndam/Downloads/dma_ip_drivers-master/XDMA/linux-kernel/xdma/xdma_mod.o] Error 1

The reason is, name change from pci_cleanup_aer_uncorrect_error_status() to pci_aer_clear_nonfatal_status() at https://github.com/torvalds/linux/commit/894020fdd88c1e9a74c60b67c0f19f1c7696ba2f

CentOS and RedHat 8.3 accepted the patch.