### PR TITLE
XDMA: Export public functions

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -4197,6 +4197,7 @@ free_xdev:
 	kfree(xdev);
 	return NULL;
 }
+EXPORT_SYMBOL(xdma_device_open);
 
 void xdma_device_close(struct pci_dev *pdev, void *dev_hndl)
 {
@@ -4241,6 +4242,7 @@ void xdma_device_close(struct pci_dev *pdev, void *dev_hndl)
 
 	kfree(xdev);
 }
+EXPORT_SYMBOL(xdma_device_close);
 
 void xdma_device_offline(struct pci_dev *pdev, void *dev_hndl)
 {
@@ -4298,6 +4300,7 @@ void xdma_device_offline(struct pci_dev *pdev, void *dev_hndl)
 
 	pr_info("xdev 0x%p, done.\n", xdev);
 }
+EXPORT_SYMBOL(xdma_device_offline);
 
 void xdma_device_online(struct pci_dev *pdev, void *dev_hndl)
 {
@@ -4346,6 +4349,7 @@ void xdma_device_online(struct pci_dev *pdev, void *dev_hndl)
 	xdma_device_flag_clear(xdev, XDEV_FLAG_OFFLINE);
 	pr_info("xdev 0x%p, done.\n", xdev);
 }
+EXPORT_SYMBOL(xdma_device_online);
 
 int xdma_device_restart(struct pci_dev *pdev, void *dev_hndl)
 {
@@ -4360,6 +4364,7 @@ int xdma_device_restart(struct pci_dev *pdev, void *dev_hndl)
 	pr_info("NOT implemented, 0x%p.\n", xdev);
 	return -EINVAL;
 }
+EXPORT_SYMBOL(xdma_device_restart);
 
 int xdma_user_isr_register(void *dev_hndl, unsigned int mask,
 			   irq_handler_t handler, void *dev)
@@ -4386,6 +4391,7 @@ int xdma_user_isr_register(void *dev_hndl, unsigned int mask,
 
 	return 0;
 }
+EXPORT_SYMBOL(xdma_user_isr_register);
 
 int xdma_user_isr_enable(void *dev_hndl, unsigned int mask)
 {
@@ -4404,6 +4410,7 @@ int xdma_user_isr_enable(void *dev_hndl, unsigned int mask)
 
 	return 0;
 }
+EXPORT_SYMBOL(xdma_user_isr_enable);
 
 int xdma_user_isr_disable(void *dev_hndl, unsigned int mask)
 {
@@ -4421,6 +4428,7 @@ int xdma_user_isr_disable(void *dev_hndl, unsigned int mask)
 
 	return 0;
 }
+EXPORT_SYMBOL(xdma_user_isr_disable);
 
 int engine_addrmode_set(struct xdma_engine *engine, unsigned long arg)
 {
@@ -4448,3 +4456,4 @@ int engine_addrmode_set(struct xdma_engine *engine, unsigned long arg)
 
 	return rv;
 }
+EXPORT_SYMBOL(engine_addrmode_set);


### PR DESCRIPTION
Currently, it is impossible to use libxdma API from other modules.
Fix this by exporting nonstatic functions.