### PR TITLE
XDMA: Allow compilation without CDEV

### DIFF
--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -18,7 +18,12 @@ EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
 #EXTRA_CFLAGS += -DINTERNAL_TESTING
 
 ifneq ($(KERNELRELEASE),)
-	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o
+	$(TARGET_MODULE)-objs := libxdma.o xdma_thread.o
+ifeq ($(CONFIG_XDMA_DISABLE_CDEV),y)
+	EXTRA_CFLAGS += -DCONFIG_XDMA_DISABLE_CDEV=y
+else
+	$(TARGET_MODULE)-objs += xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o
+endif
 	obj-m := $(TARGET_MODULE).o
 else
 	BUILDSYSTEM_DIR:=/lib/modules/$(shell uname -r)/build

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -31,7 +31,16 @@
 #include "libxdma_api.h"
 #include "cdev_sgdma.h"
 #include "xdma_thread.h"
+#include "version.h"
 
+
+#ifdef CONFIG_XDMA_DISABLE_CDEV
+// Define info here to prevent warnings when compiled without CDEV
+MODULE_LICENSE("Dual BSD/GPL");
+MODULE_AUTHOR("Xilinx, Inc.");
+MODULE_DESCRIPTION("Xilinx PCIe DMA library");
+MODULE_VERSION(DRV_MODULE_VERSION);
+#endif
 
 /* Module Parameters */
 static unsigned int poll_mode;


### PR DESCRIPTION
There can be cases, where the creation of character devices is
undesirable. For example when developing some drivers that only
use the API part of libxdma. In such cases, the character devices
can interfere with the driver's functionality and unnecessarily
increase the build size.

Introduce the option that allows to only compile the core part
of the library to fix that.