### PR TITLE
xdma: explicitly stop engine on transfer completion

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1002,6 +1002,7 @@ engine_service_final_transfer(struct xdma_engine *engine,
 			WARN_ON(*pdesc_completed > transfer->desc_num);
 		}
 		/* mark transfer as successfully completed */
+		engine_service_shutdown(engine);
 		transfer->state = TRANSFER_STATE_COMPLETED;
 		transfer->desc_cmpl = transfer->desc_num;
 		/* add dequeued number of descriptors during this run */

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -966,7 +966,7 @@ engine_service_final_transfer(struct xdma_engine *engine,
 				}
 			}
 
-			transfer->desc_cmpl += *pdesc_completed;
+			transfer->desc_cmpl = *pdesc_completed;
 			if (!(transfer->flags & XFER_FLAG_ST_C2H_EOP_RCVED)) {
 				return NULL;
 			}


### PR DESCRIPTION
When used with the `eop_flush` flag, the driver may be interrupted before all descriptors has been processed by the XDMA core, and it may so happen that during the interrupt processing, the engine has already processed all descriptors, but the driver is not aware of it. The proposed change explicitly stops the engine in such cases.