### PR TITLE
removed extra arguments in iocb functions starting from kernel 5.16

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -56,7 +56,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 	struct xdma_io_cb *cb = (struct xdma_io_cb *)cb_hndl;
 	struct cdev_async_io *caio = (struct cdev_async_io *)cb->private;
 	ssize_t numbytes = 0;
-	ssize_t res, res2;
+	ssize_t res;
 	int lock_stat;
 	int rv;
 
@@ -94,22 +94,23 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 
 	char_sgdma_unmap_user_buf(cb, cb->write);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	caio->res2 |= (err < 0) ? err : 0;
 	if (caio->res2)
 		caio->err_cnt++;
+#endif
 
 	caio->cmpl_cnt++;
 	caio->res += numbytes;
 
 	if (caio->cmpl_cnt == caio->req_cnt) {
 		res = caio->res;
-		res2 = caio->res2;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
-		caio->iocb->ki_complete(caio->iocb, res2);
+		caio->iocb->ki_complete(caio->iocb, res);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-		caio->iocb->ki_complete(caio->iocb, res, res2);
+		caio->iocb->ki_complete(caio->iocb, res, caio->res2);
 #else
-		aio_complete(caio->iocb, res, res2);
+		aio_complete(caio->iocb, res, caio->res2);
 #endif
 skip_tran:
 		spin_unlock(&caio->lock);
@@ -122,7 +123,7 @@ skip_tran:
 
 skip_dev_lock:
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
-	caio->iocb->ki_complete(caio->iocb, -EBUSY);
+	caio->iocb->ki_complete(caio->iocb, numbytes);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY);
 #else

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -111,7 +111,9 @@ struct cdev_async_io {
 	struct work_struct wrk_itm;
 	struct cdev_async_io *next;
 	ssize_t res;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	ssize_t res2;
+#endif
 	int err_cnt;
 };
 


### PR DESCRIPTION
Fixes #149 

Tested on 5.16 - it works.