### PR TITLE
Allow millisecond DMA timeouts.

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -36,13 +36,13 @@
 #include "xdma_thread.h"
 
 /* Module Parameters */
-unsigned int h2c_timeout = 10;
-module_param(h2c_timeout, uint, 0644);
-MODULE_PARM_DESC(h2c_timeout, "H2C sgdma timeout in seconds, default is 10 sec.");
+unsigned int h2c_timeout_ms = 10000;
+module_param(h2c_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(h2c_timeout_ms, "H2C sgdma timeout in milliseconds, default is 10 seconds.");
 
-unsigned int c2h_timeout = 10;
-module_param(c2h_timeout, uint, 0644);
-MODULE_PARM_DESC(c2h_timeout, "C2H sgdma timeout in seconds, default is 10 sec.");
+unsigned int c2h_timeout_ms = 10000;
+module_param(c2h_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(c2h_timeout_ms, "C2H sgdma timeout in milliseconds, default is 10 seconds.");
 
 extern struct kmem_cache *cdev_cache;
 static void char_sgdma_unmap_user_buf(struct xdma_io_cb *cb, bool write);
@@ -89,8 +89,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 		numbytes = xdma_xfer_completion((void *)cb, xdev,
 				engine->channel, cb->write, cb->ep_addr,
 				&cb->sgt, 0, 
-				cb->write ? h2c_timeout * 1000 :
-					    c2h_timeout * 1000);
+				cb->write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(cb, cb->write);
 
@@ -392,8 +391,7 @@ static ssize_t char_sgdma_read_write(struct file *file, const char __user *buf,
 		return rv;
 
 	res = xdma_xfer_submit(xdev, engine->channel, write, *pos, &cb.sgt,
-				0, write ? h2c_timeout * 1000 :
-					   c2h_timeout * 1000);
+				0, write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(&cb, write);
 
@@ -476,7 +474,7 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
-					0, h2c_timeout * 1000);
+					0, h2c_timeout_ms);
 	}
 
 	if (engine->cmplthp)
@@ -550,7 +548,7 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
-					0, c2h_timeout * 1000);
+					0, c2h_timeout_ms);
 	}
 
 	if (engine->cmplthp)
@@ -776,8 +774,7 @@ static int ioctl_do_aperture_dma(struct xdma_engine *engine, unsigned long arg,
 
 	io.error = 0;
 	res = xdma_xfer_aperture(engine, write, io.ep_addr, io.aperture,
-				&cb.sgt, 0, write ? h2c_timeout * 1000 :
-						c2h_timeout * 1000);
+				&cb.sgt, 0, write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(&cb, write);
 	if (res < 0)

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -360,8 +360,8 @@ static int xdma_mod_init(void)
 
 	if (desc_blen_max > XDMA_DESC_BLEN_MAX)
 		desc_blen_max = XDMA_DESC_BLEN_MAX;
-	pr_info("desc_blen_max: 0x%x/%u, timeout: h2c %u c2h %u sec.\n",
-		desc_blen_max, desc_blen_max, h2c_timeout, c2h_timeout);
+	pr_info("desc_blen_max: 0x%x/%u, timeout: h2c %u c2h %u (ms)\n",
+		desc_blen_max, desc_blen_max, h2c_timeout_ms, c2h_timeout_ms);
 
 	rv = xdma_cdev_init();
 	if (rv < 0)

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -55,8 +55,8 @@
 #define MAGIC_BITSTREAM 0xBBBBBBBBUL
 
 extern unsigned int desc_blen_max;
-extern unsigned int h2c_timeout;
-extern unsigned int c2h_timeout;
+extern unsigned int h2c_timeout_ms;
+extern unsigned int c2h_timeout_ms;
 
 struct xdma_cdev {
 	unsigned long magic;		/* structure ID for sanity checks */


### PR DESCRIPTION
Useful if DMA timeouts represent a recoverable error.