### PR TITLE
CR-1132444 skip pci_request_regions() call if XRT macro is defined

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.c
@@ -18,9 +18,9 @@
 #include "qdma_platform.h"
 #include "qdma_soft_reg.h"
 #include "qdma_soft_access.h"
-#include "qdma_cpm4_access.h"
+#include "qdma_cpm4_access/qdma_cpm4_access.h"
 #include "eqdma_soft_access.h"
-#include "eqdma_cpm5_access.h"
+#include "eqdma_cpm5_access/eqdma_cpm5_access.h"
 #include "qdma_reg_dump.h"
 
 #ifdef ENABLE_WPP_TRACING

--- a/QDMA/linux-kernel/driver/libqdma/xdev.c
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.c
@@ -244,7 +244,6 @@ release_regions:
 #ifndef _XRT_
 	pci_release_regions(pdev);
 #endif
-	return;
 }
 #endif
 

--- a/QDMA/linux-kernel/driver/libqdma/xdev.c
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.c
@@ -213,7 +213,10 @@ static void xdev_reset_work(struct work_struct *work)
 		rv = pci_enable_device(pdev);
 		if (rv) {
 			pr_err("cannot enable PCI device\n");
-			goto release_regions;
+#ifndef _XRT_
+			pci_release_regions(pdev);
+#endif
+			return;
 		}
 
 		/* enable relaxed ordering */
@@ -237,13 +240,6 @@ static void xdev_reset_work(struct work_struct *work)
 		qdma_device_offline(pdev, (unsigned long)xdev,
 							XDEV_FLR_INACTIVE);
 	}
-
-	return;
-
-release_regions:
-#ifndef _XRT_
-	pci_release_regions(pdev);
-#endif
 }
 #endif
 

--- a/QDMA/linux-kernel/driver/libqdma/xdev.c
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.c
@@ -1199,8 +1199,8 @@ disable_device:
 	pci_disable_relaxed_ordering(pdev);
 	pci_disable_device(pdev);
 
-#ifndef _XRT_
 release_regions:
+#ifndef _XRT_
 	pci_release_regions(pdev);
 #endif
 

--- a/QDMA/linux-kernel/driver/libqdma/xdev.c
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.c
@@ -202,7 +202,7 @@ static void xdev_reset_work(struct work_struct *work)
 		pci_release_regions(pdev);
 		pci_disable_device(pdev);
 
-#ifndef _XRT_
+#ifndef __XRT__
 		rv = pci_request_regions(pdev, "qdma-vf");
 		if (rv) {
 			pr_err("cannot obtain PCI resources\n");
@@ -213,7 +213,7 @@ static void xdev_reset_work(struct work_struct *work)
 		rv = pci_enable_device(pdev);
 		if (rv) {
 			pr_err("cannot enable PCI device\n");
-#ifndef _XRT_
+#ifndef __XRT__
 			pci_release_regions(pdev);
 #endif
 			return;
@@ -1000,7 +1000,7 @@ int qdma_device_open(const char *mod_name, struct qdma_dev_conf *conf,
 		return -EINVAL;
 	}
 
-#ifndef _XRT_
+#ifndef __XRT__
 	rv = pci_request_regions(pdev, mod_name);
 	if (rv) {
 		/* Just info, some other driver may have claimed the device. */
@@ -1195,7 +1195,7 @@ disable_device:
 	pci_disable_device(pdev);
 
 release_regions:
-#ifndef _XRT_
+#ifndef __XRT__
 	pci_release_regions(pdev);
 #endif
 
@@ -1247,7 +1247,7 @@ int qdma_device_close(struct pci_dev *pdev, unsigned long dev_hndl)
 
 	pci_disable_relaxed_ordering(pdev);
 	pci_disable_extended_tag(pdev);
-#ifndef _XRT_
+#ifndef __XRT__
 	pci_release_regions(pdev);
 #endif
 	pci_disable_device(pdev);


### PR DESCRIPTION
XRT driver defines a macro "_XRT_" for adding XRT specific changes in QDMA driver.
pci_request_regions() call in XRT creates extra node in the resource tree, and has no functionality impact. So, this call is not necessary in XRT so skip calling this API in QDMA driver using _XRT_ macro.
Earlier, this same change has been done for XDMA & QDMA drivers also whose were part of XRT repo in previous releases.