### PR TITLE
Fix coverity issues reported in QDMA driver

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
@@ -2193,7 +2193,7 @@ static int dump_eqdma_cpm5_context(struct qdma_descq_context *queue_context,
 	int n;
 	int len = 0;
 	int rv;
-	char banner[DEBGFS_LINE_SZ];
+	char banner[DEBGFS_LINE_SZ] = "";
 
 	if (queue_context == NULL) {
 		qdma_log_error("%s: queue_context is NULL, err:%d\n",
@@ -2652,7 +2652,7 @@ static int dump_eqdma_cpm5_intr_context(struct qdma_indirect_intr_ctxt
 	int n;
 	int len = 0;
 	int rv;
-	char banner[DEBGFS_LINE_SZ];
+	char banner[DEBGFS_LINE_SZ] = "";
 
 	eqdma_cpm5_fill_intr_ctxt(intr_ctx);
 

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
@@ -1411,7 +1411,7 @@ static int dump_cpm4_context(struct qdma_descq_context *queue_context,
 	int n;
 	int len = 0;
 	int rv;
-	char banner[DEBGFS_LINE_SZ];
+	char banner[DEBGFS_LINE_SZ] = "";
 
 	if (queue_context == NULL) {
 		qdma_log_error("%s: queue_context is NULL, err:%d\n",
@@ -1925,7 +1925,7 @@ static int dump_cpm4_intr_context(struct qdma_indirect_intr_ctxt *intr_ctx,
 	int n;
 	int len = 0;
 	int rv;
-	char banner[DEBGFS_LINE_SZ];
+	char banner[DEBGFS_LINE_SZ] = "";
 
 	qdma_cpm4_fill_intr_ctxt(intr_ctx);
 


### PR DESCRIPTION
*** CID 274026:  Uninitialized variables  (UNINIT)
/build/Release/usr/src/xrt-2.14.0/driver/xocl/lib/libqdma/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c: 2430 in dump_eqdma_cpm5_context()

Signed-off-by: Rajkumar Rampelli <rampelli@amd.com>