### PR TITLE
[1] Remove usage of the deprecated "pci-dma-compat.h" API [2] string overflow fix

### DIFF
--- a/QDMA/linux-kernel/apps/dma-latency/dmalat.c
+++ b/QDMA/linux-kernel/apps/dma-latency/dmalat.c
@@ -871,7 +871,7 @@ static void parse_config_file(const char *cfg_fname)
 		printf("Could not open %s\n", rng_sz_path);
 		exit(1);
 	}
-	ret = read(rng_sz_fd, &rng_sz[1], 100);
+	ret = read(rng_sz_fd, &rng_sz[1], 99);
 	if (ret < 0) {
 		printf("Error: Could not read the file\n");
 		exit(1);

--- a/QDMA/linux-kernel/apps/dma-perf/dmaperf.c
+++ b/QDMA/linux-kernel/apps/dma-perf/dmaperf.c
@@ -1051,7 +1051,7 @@ static void parse_config_file(const char *cfg_fname)
 		printf("Could not open %s\n", rng_sz_path);
 		exit(1);
 	}
-	ret = read(rng_sz_fd, &rng_sz[1], 100);
+	ret = read(rng_sz_fd, &rng_sz[1], 99);
 	if (ret < 0) {
 		printf("Error: Could not read the file\n");
 		exit(1);

--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
@@ -2302,8 +2302,8 @@ void sgl_unmap(struct pci_dev *pdev, struct qdma_sw_sg *sg, unsigned int sgcnt,
 		if (!sg->pg)
 			break;
 		if (sg->dma_addr) {
-			pci_unmap_page(pdev, sg->dma_addr - sg->offset,
-							PAGE_SIZE, dir);
+			dma_unmap_page(&pdev->dev, sg->dma_addr - sg->offset,
+				       PAGE_SIZE, dir);
 			sg->dma_addr = 0UL;
 		}
 	}
@@ -2334,8 +2334,9 @@ int sgl_map(struct pci_dev *pdev, struct qdma_sw_sg *sgl, unsigned int sgcnt,
 	 */
 	for (i = 0; i < sgcnt; i++, sg++) {
 		/* !! TODO  page size !! */
-		sg->dma_addr = pci_map_page(pdev, sg->pg, 0, PAGE_SIZE, dir);
-		if (unlikely(pci_dma_mapping_error(pdev, sg->dma_addr))) {
+		sg->dma_addr = dma_map_page(&pdev->dev, sg->pg, 0, PAGE_SIZE,
+					    dir);
+		if (unlikely(dma_mapping_error(&pdev->dev, sg->dma_addr))) {
 			pr_err("map sgl failed, sg %d, %u.\n", i, sg->len);
 			if (i)
 				sgl_unmap(pdev, sgl, i, dir);

--- a/QDMA/linux-kernel/driver/libqdma/qdma_st_c2h.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_st_c2h.c
@@ -216,7 +216,7 @@ static inline int flq_fill_page_one(struct qdma_sw_pg_sg *pg_sdesc,
 	}
 
 	mapping = dma_map_page(dev, pg, 0, (PAGE_SIZE << pg_order),
-				PCI_DMA_FROMDEVICE);
+				DMA_FROM_DEVICE);
 	if (unlikely(dma_mapping_error(dev, mapping))) {
 		dev_err(dev, "page 0x%p mapping error 0x%llx.\n",
 			pg, (unsigned long long)mapping);

--- a/QDMA/linux-kernel/driver/libqdma/xdev.c
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.c
@@ -91,12 +91,12 @@ struct qdma_resource_lock {
 static int pci_dma_mask_set(struct pci_dev *pdev)
 {
 	/** 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/** use 64-bit DMA for descriptors */
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
 		/** use 64-bit DMA, 32-bit for consistent */
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/** use 32-bit DMA */
 		dev_info(&pdev->dev, "Using a 32-bit DMA mask.\n");
 	} else {

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2908,7 +2908,7 @@ static void transfer_destroy(struct xdma_dev *xdev, struct xdma_transfer *xfer)
 		struct sg_table *sgt = xfer->sgt;
 
 		if (sgt->nents) {
-			pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents,
+			dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->nents,
 				     xfer->dir);
 			sgt->nents = 0;
 		}
@@ -3192,8 +3192,8 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		sgt->nents = pci_map_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
-					dir);
+		sgt->nents = dma_map_sg(&xdev->pdev->dev, sgt->sgl,
+					sgt->orig_nents, dir);
 		if (!sgt->nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3434,7 +3434,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3504,7 +3504,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3660,7 +3660,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3781,7 +3781,7 @@ ssize_t xdma_xfer_completion(void *cb_hndl, void *dev_hndl, int channel,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3855,7 +3855,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3895,8 +3895,8 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 			pr_info("transfer_init failed\n");
 
 			if (!dma_mapped && sgt->nents) {
-				pci_unmap_sg(xdev->pdev, sgt->sgl,
-						sgt->orig_nents, dir);
+				dma_unmap_sg(&xdev->pdev->dev, sgt->sgl,
+					     sgt->orig_nents, dir);
 				sgt->nents = 0;
 			}
 
@@ -3943,7 +3943,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&xdev->pdev->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -4191,16 +4191,16 @@ static int set_dma_mask(struct pci_dev *pdev)
 
 	dbg_init("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
 	/* 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		dbg_init("pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(64));
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		dbg_init("Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_coherent_mask(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		dbg_init("Using a 32-bit DMA mask.\n");
 	} else {


### PR DESCRIPTION
The library does not compile against modern kernels (probably > 5.18).  This PR fixes that.

The patches were generated automatically so additional manual edits may be required. They have been tested on hardware using latest [XRT](https://github.com/xilinx/XRT) that integrates this repo as a library  (GCC 12.2.0, Linux 5.19.2) .