### PR TITLE
DMA compat fix for Linux 5.19

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -56,7 +56,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 	struct xdma_io_cb *cb = (struct xdma_io_cb *)cb_hndl;
 	struct cdev_async_io *caio = (struct cdev_async_io *)cb->private;
 	ssize_t numbytes = 0;
-	ssize_t res, res2;
+	ssize_t res;
 	int lock_stat;
 	int rv;
 
@@ -88,38 +88,43 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 	if (!err)
 		numbytes = xdma_xfer_completion((void *)cb, xdev,
 				engine->channel, cb->write, cb->ep_addr,
-				&cb->sgt, 0, 
+				&cb->sgt, 0,
 				cb->write ? h2c_timeout * 1000 :
 					    c2h_timeout * 1000);
 
 	char_sgdma_unmap_user_buf(cb, cb->write);
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	caio->res2 |= (err < 0) ? err : 0;
 	if (caio->res2)
 		caio->err_cnt++;
+#endif
 
 	caio->cmpl_cnt++;
 	caio->res += numbytes;
 
 	if (caio->cmpl_cnt == caio->req_cnt) {
 		res = caio->res;
-		res2 = caio->res2;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-		caio->iocb->ki_complete(caio->iocb, res, res2);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+		caio->iocb->ki_complete(caio->iocb, res);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+		caio->iocb->ki_complete(caio->iocb, res, caio->res2);
 #else
-		aio_complete(caio->iocb, res, res2);
+		aio_complete(caio->iocb, res, caio->res2);
 #endif
 skip_tran:
 		spin_unlock(&caio->lock);
 		kmem_cache_free(cdev_cache, caio);
 		kfree(cb);
 		return;
-	} 
+	}
 	spin_unlock(&caio->lock);
 	return;
 
 skip_dev_lock:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
+	caio->iocb->ki_complete(caio->iocb, numbytes);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY);
 #else
 	aio_complete(caio->iocb, numbytes, -EBUSY);
@@ -795,7 +800,7 @@ static int ioctl_do_aperture_dma(struct xdma_engine *engine, unsigned long arg,
 
 	return io.error;
 }
-	
+
 static long char_sgdma_ioctl(struct file *file, unsigned int cmd,
 		unsigned long arg)
 {

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -111,7 +111,9 @@ struct cdev_async_io {
 	struct work_struct wrk_itm;
 	struct cdev_async_io *next;
 	ssize_t res;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	ssize_t res2;
+#endif
 	int err_cnt;
 };
 


### PR DESCRIPTION
This PR contains two commits:
- b09bd558ed11f77945510da11ec8caf26eedfe3a takes into account the obsolescence of `linux/pci-dma-compat.h` - XDMA fails to compile in recent kernels without that.
- 51274f92927bfc3b6aaaea1ad4a3413317e9030b re-applies the currently unmerged fixes for kernels 5.16 and above.
