### PR TITLE
added irq_index as additional argument to user isr call back

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.h
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.h
@@ -470,6 +470,7 @@ struct qdma_dev_conf {
 	u32 bdf;
 	/** index of device in device list */
 	u32 idx;
+#ifndef __XRT__
 	/**
 	 *  @brief  user interrupt, if null, default libqdma handler is used
 	 *
@@ -477,7 +478,16 @@ struct qdma_dev_conf {
 	 *  @param uld		upper layer data, i.e. callback data
 	 */
 	void (*fp_user_isr_handler)(unsigned long dev_hndl, unsigned long uld);
-
+#else
+	/**
+	 *  @brief  user interrupt, if null, default libqdma handler is used
+	 *
+	 *  @param dev_hndl	Device Handler
+	 *  @param irq_index    Interrupt index
+	 *  @param uld		upper layer data, i.e. callback data
+	 */
+	void (*fp_user_isr_handler)(unsigned long dev_hndl,int irq_index, unsigned long uld);
+#endif
 	/**
 	 *  @brief  Q interrupt top,
 	 *  per-device addtional handling code

--- a/QDMA/linux-kernel/driver/libqdma/qdma_intr.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_intr.c
@@ -119,9 +119,15 @@ static irqreturn_t user_intr_handler(int irq_index, int irq, void *dev_id)
 	pr_info("User IRQ fired on Funtion#%d: index=%d, vector=%d\n",
 		xdev->func_id, irq_index, irq);
 
-	if (xdev->conf.fp_user_isr_handler)
+	if (xdev->conf.fp_user_isr_handler) {
+#ifndef __XRT__
 		xdev->conf.fp_user_isr_handler((unsigned long)xdev,
 						xdev->conf.uld);
+#else
+		xdev->conf.fp_user_isr_handler((unsigned long)xdev,
+						irq_index, xdev->conf.uld);
+#endif
+	}
 
 	return IRQ_HANDLED;
 }


### PR DESCRIPTION
**Issue:**
Interrupt index is not passed to the client driver from qdma driver today. It is not possible to handle separate isrs for separate interrupt vectors.  

**Resolution**
Sending irq_index as additional argument to user isr call back