### PR TITLE
Coverify fixes in QDMA driver

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.h
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.h
@@ -404,7 +404,7 @@ struct qdma_dev_conf {
 	/** pointer to pci_dev */
 	struct pci_dev *pdev;
 	/** Maximum number of queue pairs per device */
-	unsigned short qsets_max;
+	u32 qsets_max;
 	/** Reserved */
 	unsigned short rsvd2;
 	/**

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_soft_access/eqdma_soft_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_soft_access/eqdma_soft_access.c
@@ -2544,7 +2544,7 @@ static int dump_eqdma_context(struct qdma_descq_context *queue_context,
 	int n;
 	int len = 0;
 	int rv;
-	char banner[DEBGFS_LINE_SZ];
+	char banner[DEBGFS_LINE_SZ] = "";
 
 	if (queue_context == NULL) {
 		qdma_log_error("%s: queue_context is NULL, err:%d\n",

--- a/QDMA/linux-kernel/driver/libqdma/qdma_intr.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_intr.c
@@ -284,8 +284,6 @@ static void data_intr_direct(struct xlnx_dma_dev *xdev, int vidx, int irq,
 			  flags);
 	list_for_each_safe(entry, tmp, descq_list) {
 		descq = container_of(entry, struct qdma_descq, intr_list);
-		if (!descq)
-			continue;
 
 		if (descq->conf.ping_pong_en &&
 				descq->conf.q_type == Q_C2H && descq->conf.st)

--- a/QDMA/linux-kernel/driver/libqdma/qdma_regs.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_regs.c
@@ -582,11 +582,16 @@ int qdma_queue_cmpl_ctrl(unsigned long dev_hndl, unsigned long id,
 		unlock_descq(descq);
 
 	} else {
+		lock_descq(descq);
 		/* read the setting */
 		rv = queue_cmpt_cidx_read(descq->xdev,
 				descq->conf.qidx, &descq->cmpt_cidx_info);
-		if (unlikely(rv < 0))
+		if (unlikely(rv < 0)) {
+			pr_err("%s: Failed to read cmpt cidx\n",
+			       descq->conf.name);
+			unlock_descq(descq);
 			return rv;
+		}
 
 		cctrl->trigger_mode = descq->conf.cmpl_trig_mode =
 				descq->cmpt_cidx_info.trig_mode;
@@ -598,6 +603,7 @@ int qdma_queue_cmpl_ctrl(unsigned long dev_hndl, unsigned long id,
 				descq->cmpt_cidx_info.wrb_en;
 		cctrl->cmpl_en_intr = descq->conf.cmpl_en_intr =
 				descq->cmpt_cidx_info.irq_en;
+		unlock_descq(descq);
 	}
 
 	return 0;

--- a/QDMA/linux-kernel/driver/libqdma/xdev.c
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.c
@@ -1117,7 +1117,7 @@ int qdma_device_open(const char *mod_name, struct qdma_dev_conf *conf,
 
 	rv = qdma_dev_qinfo_get(xdev->dma_device_index, xdev->func_id,
 				&xdev->conf.qsets_base,
-				(uint32_t *) &xdev->conf.qsets_max);
+				&xdev->conf.qsets_max);
 	if (rv < 0) {
 		rv = qdma_dev_entry_create(xdev->dma_device_index,
 				xdev->func_id);


### PR DESCRIPTION
CID 211019 : remove dead code in qdma_intr.c | data_intr_direct() CID 249237 : missing_lock: Accessing reg_info->trig_mode without holding lock CID 249253 : missing_lock: Accessing descq->q_state without holding lock CID 257805 : Pointer &xdev->conf.qsets_max points to an object whose
             effective type is unsigned short (16 bits, unsigned) but is
             dereferenced as a wider unsigned int (32 bits, unsigned). This may
             lead to memory corruption.
CID 257809 : missing_lock: Accessing descq->cmpt_cidx_info.trig_mode without
	     holding lock qdma_descq.lock
CID 257810 : missing_lock: Accessing descq->conf.cmpl_trig_mode without holding
	     lock qdma_descq.lock.
CID 257811 : missing_lock: Accessing descq->conf.cmpl_trig_mode without holding
	     lock qdma_descq.lock
CID 216748: Uninitialized scalar variable