### PR TITLE
CR-1156069 Update condition for data transfer complete event to wait for

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
@@ -254,8 +254,9 @@ static int qdma_request_wait_for_cmpl(struct xlnx_dma_dev *xdev,
 	 */
 
 	if (req->timeout_ms)
-		qdma_waitq_wait_event_timeout(cb->wq, cb->done,
-			msecs_to_jiffies(req->timeout_ms));
+		qdma_waitq_wait_event_timeout(cb->wq, cb->done &&
+					(descq->pidx == descq->cidx),
+					msecs_to_jiffies(req->timeout_ms));
 	else
 		qdma_waitq_wait_event(cb->wq, cb->done);
 

--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
@@ -253,12 +253,18 @@ static int qdma_request_wait_for_cmpl(struct xlnx_dma_dev *xdev,
 	 *  call back is completed
 	 */
 
-	if (req->timeout_ms)
+	if (req->timeout_ms) {
+#ifdef __XRT__
 		qdma_waitq_wait_event_timeout(cb->wq, cb->done &&
 					(descq->pidx == descq->cidx),
 					msecs_to_jiffies(req->timeout_ms));
-	else
+#else
+		qdma_waitq_wait_event_timeout(cb->wq, cb->done,
+					msecs_to_jiffies(req->timeout_ms));
+#endif
+	} else {
 		qdma_waitq_wait_event(cb->wq, cb->done);
+	}
 
 	lock_descq(descq);
 	/** if the call back is not done, request timed out


### PR DESCRIPTION
Added a new condition in wait_event_interruptible_timeout() to wait for both descq pidx & cidx values to be equal. It will guarantee the data transfer complete and client driver reads the proper data in multi application data transfer test.
`Logic in QDMA driver:
1. QDMA driver receives data request from client/host driver
2. It starts analyzing the received request (read/write), descriptors etc. Sets cb->done = 0; And, Initialize the wait queue.
3. It starts processing request
3.1. for each request it starts setting cb->done = 1 & wakeups waiting queue.
3.2. Programs the pending requests pid values in PIDx register. DMA engine invokes data transfer in this step. Once transfer completed, requests/descq pidx, cidx values will be equal.
4. It starts waiting for cb->done = 1 or timeout lapsed. wait_event_interruptible_timeout(<>, cb->done, timeout);
4.1. wait_event_*() will be terminated once cb->done is 1 which is updated in step 3.1
4.2. It will return the number of bytes to be transferred as a return value to client driver.
4.3. Tried reading the requests pidx & cidx values, they are not equal, meaning data transfer is not yet completed. This might be the reason, if client drivers adds 1 milli sec delay, it is able to read proper response.`