### PR TITLE
fix vm_flags modification for Linux v6.3

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,7 +233,11 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
+#if KERNEL_VERSION(6, 3, 0) <= LINUX_VERSION_CODE
+	vm_flags_set(vma, VMEM_FLAGS);
+#else
 	vma->vm_flags |= VMEM_FLAGS;
+#endif
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);


### PR DESCRIPTION
The [vm_flags modifier functions](https://lore.kernel.org/all/20230126193752.297968-1-surenb@google.com/) have been introduced to prevent racing since Linux Kernel v6.3. However, the vm_flags have become const since this version. This PR changed the modified code to adopt the new function wrapper for the newer version of the kernel.

I have tested it after cherry-picking #179 , #142 (only xvsec) and #150 in my [own branch](https://github.com/cyyself/dma_ip_drivers/tree/fix-6.3). It was successfully compiled on Linux v6.3.