### PR TITLE
aquiring and releasing descq lock could be asymmetric in qdma_queue_u…

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_descq.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_descq.c
@@ -981,8 +981,8 @@ int qdma_queue_update_pointers(unsigned long dev_hndl, unsigned long qhndl)
 		return -EINVAL;
 	}
 
+	lock_descq(descq);
 	if (descq->conf.st && (descq->conf.q_type == Q_C2H)) {
-		lock_descq(descq);
 		if (descq->q_state == Q_STATE_ONLINE) {
 			ret = queue_cmpt_cidx_update(descq->xdev,
 					descq->conf.qidx,


### PR DESCRIPTION
lock_descq() and unlock_descq() calls are out of sync if the condition '(descq->conf.st && (descq->conf.q_type == Q_C2H)' is not met.