### PR TITLE
Make XDMA driver compatible with linux kernel >= 5.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# Forked Xilinx DMA IP Reference drivers
-
-The official driver didn't work for me when the kernel changed somewhere in kernel 5.x.x.
-This repository is mainly used for my raspberry pi work 
+# Xilinx DMA IP Reference drivers
 
 ## Xilinx QDMA
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Xilinx DMA IP Reference drivers
+# Forked Xilinx DMA IP Reference drivers
+
+The official driver didn't work for me when the kernel changed somewhere in kernel 5.x.x.
+This repository is mainly used for my raspberry pi work 
 
 ## Xilinx QDMA
 

--- a/XDMA/linux-kernel/readme.txt
+++ b/XDMA/linux-kernel/readme.txt
@@ -113,7 +113,9 @@ Usage:
   - Change directory to the driver directory.
         cd xdma
   - Compile and install the kernel module driver.
-        make install
+        sudo make install
+  - Generate modules.dep and map files
+	sudo depmod
   - Change directory to the tools directory.
         cd tools
   - Compile the provided example test tools.

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,7 +233,9 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
-	vma->vm_flags |= VMEM_FLAGS;
+	 
+	vm_flags_mod(vma, VMEM_FLAGS, 0);
+	// vma->__vm_flags |= VMEM_FLAGS; /* TODO: uncomment. important */	
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,10 +233,12 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
-	 
+	
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
 	vm_flags_mod(vma, VMEM_FLAGS, 0);
-	// vma->__vm_flags |= VMEM_FLAGS; /* TODO: uncomment. important */	
-	/* make MMIO accessible to user space */
+#else
+	vma->vm_flags |= VMEM_FLAGS; /* make MMIO accessible to user space */
+#endif	
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);
 	dbg_sg("vma=0x%p, vma->vm_start=0x%lx, phys=0x%lx, size=%lu = %d\n",

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -105,7 +105,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 		res = caio->res;
 		res2 = caio->res2;
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-		caio->iocb->ki_complete(caio->iocb, res, res2);
+		caio->iocb->ki_complete(caio->iocb, res);
 #else
 		aio_complete(caio->iocb, res, res2);
 #endif
@@ -120,7 +120,7 @@ skip_tran:
 
 skip_dev_lock:
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY);
+	caio->iocb->ki_complete(caio->iocb, numbytes);
 #else
 	aio_complete(caio->iocb, numbytes, -EBUSY);
 #endif

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -567,12 +567,12 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
+	return cdev_aio_write(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
+	return cdev_aio_read(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -567,12 +567,12 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -567,12 +567,20 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 	return cdev_aio_write(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#else
+	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif	
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_read(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+		return cdev_aio_read(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#else
+		return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -125,7 +125,7 @@ skip_dev_lock:
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
 	caio->iocb->ki_complete(caio->iocb, numbytes);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
-	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY)
+	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY);
 #else
 	aio_complete(caio->iocb, numbytes, -EBUSY);
 #endif

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -104,8 +104,11 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 	if (caio->cmpl_cnt == caio->req_cnt) {
 		res = caio->res;
 		res2 = caio->res2;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
 		caio->iocb->ki_complete(caio->iocb, res);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+		caio->iocb->ki_complete(caio->iocb, res, res2);
 #else
 		aio_complete(caio->iocb, res, res2);
 #endif
@@ -119,8 +122,10 @@ skip_tran:
 	return;
 
 skip_dev_lock:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
 	caio->iocb->ki_complete(caio->iocb, numbytes);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+	caio->iocb->ki_complete(caio->iocb, numbytes, -EBUSY)
 #else
 	aio_complete(caio->iocb, numbytes, -EBUSY);
 #endif

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2908,7 +2908,7 @@ static void transfer_destroy(struct xdma_dev *xdev, struct xdma_transfer *xfer)
 		struct sg_table *sgt = xfer->sgt;
 
 		if (sgt->nents) {
-			pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents,
+			dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->nents,
 				     xfer->dir);
 			sgt->nents = 0;
 		}
@@ -3192,7 +3192,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		sgt->nents = pci_map_sg(xdev->pdev, sgt->sgl, sgt->orig_nents,
+		sgt->nents = dma_map_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents,
 					dir);
 		if (!sgt->nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
@@ -3434,7 +3434,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3504,7 +3504,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&(xdev->pdev)->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3660,7 +3660,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3781,7 +3781,7 @@ ssize_t xdma_xfer_completion(void *cb_hndl, void *dev_hndl, int channel,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -3855,7 +3855,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = dma_map_sg(&(xdev->pdev)->dev, sg, sgt->orig_nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -3895,7 +3895,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 			pr_info("transfer_init failed\n");
 
 			if (!dma_mapped && sgt->nents) {
-				pci_unmap_sg(xdev->pdev, sgt->sgl,
+				dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl,
 						sgt->orig_nents, dir);
 				sgt->nents = 0;
 			}
@@ -3943,7 +3943,7 @@ ssize_t xdma_xfer_submit_nowait(void *cb_hndl, void *dev_hndl, int channel,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		dma_unmap_sg(&(xdev->pdev)->dev, sgt->sgl, sgt->orig_nents, dir);
 		sgt->nents = 0;
 	}
 
@@ -4191,16 +4191,16 @@ static int set_dma_mask(struct pci_dev *pdev)
 
 	dbg_init("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
 	/* 64-bit addressing capability for XDMA? */
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) {
+	if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(64))) {
 		/* query for DMA transfer */
 		/* @see Documentation/DMA-mapping.txt */
 		dbg_init("pci_set_dma_mask()\n");
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64));
-	} else if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) {
+		dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	} else if (!dma_set_mask(&pdev->dev, DMA_BIT_MASK(32))) {
 		dbg_init("Could not set 64-bit DMA mask.\n");
-		pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(32));
+		dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
 		/* use 32-bit DMA */
 		dbg_init("Using a 32-bit DMA mask.\n");
 	} else {

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,7 @@ fail:
 
 int xdma_cdev_init(void)
 {
-	g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+	g_xdma_class = class_create(XDMA_NODE_NAME);
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,11 @@ fail:
 
 int xdma_cdev_init(void)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 	g_xdma_class = class_create(XDMA_NODE_NAME);
+#else
+	g_xdma_class = class_create(THIS_MODULE ,XDMA_NODE_NAME);
+#endif
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;


### PR DESCRIPTION
I was having trouble getting the driver to compile on my raspberry pi

with this patch its working again. adjusted caio->iocb->ki_complete call to the new function signature if compiled on kernel >= 5.16

and switched the deprecated pci_unmap_sg to the new dma_unmap_sg as well as the set_dma_mask functions