### PR TITLE
Do not include http reference to prohibited sources

### DIFF
--- a/QDMA/windows/README.md
+++ b/QDMA/windows/README.md
@@ -261,6 +261,6 @@ _____________________________________________________________________________
 
     [ref1]: https://www.xilinx.com/products/intellectual-property/pcie-dma.html
     [ref2]: https://www.xilinx.com/support/documentation/ip_documentation/qdma/v3_0/pg302-qdma.pdf
-    [ref3]: https://developer.microsoft.com/en-us/windows/hardware/windows-driver-kit
-    [ref4]: https://msdn.microsoft.com/en-us/windows/hardware/drivers/develop/building-a-driver
-    [ref5]: https://msdn.microsoft.com/en-us/windows/hardware/drivers/install/the-testsigning-boot-configuration-option
+    [ref3]: see Microsoft developer documentation on windows driver kit
+    [ref4]: see Microsoft documentation on msdn for building a driver
+    [ref5]: see Microsoft documentation on msdn for how test signing boot configuration option


### PR DESCRIPTION
Per AMD policy no reference to prohibited sources can be include as code comments or in documentation.

Please check with @stsoe for copy of internal  guidelines.

This pull request is to remediate a legal scan of XRT which uses QDMA as submodule.