### PR TITLE
Kernel 6.4 xdma compile fixes

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -237,6 +237,7 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	vm_flags_set(vma, VMEM_FLAGS);
 #else
 	vma->vm_flags |= VMEM_FLAGS;
+#endif
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,6 +233,9 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	vm_flags_set(vma, VMEM_FLAGS);
+#else
 	vma->vm_flags |= VMEM_FLAGS;
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -568,14 +568,22 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
+#else
 	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
+#else
 	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
-}
 #endif
+}
+#endif // LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 
 static int ioctl_do_perf_start(struct xdma_engine *engine, unsigned long arg)
 {

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -56,7 +56,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 	struct xdma_io_cb *cb = (struct xdma_io_cb *)cb_hndl;
 	struct cdev_async_io *caio = (struct cdev_async_io *)cb->private;
 	ssize_t numbytes = 0;
-	ssize_t res;
+	ssize_t res, res2;
 	int lock_stat;
 	int rv;
 
@@ -94,11 +94,9 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 
 	char_sgdma_unmap_user_buf(cb, cb->write);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	caio->res2 |= (err < 0) ? err : 0;
 	if (caio->res2)
 		caio->err_cnt++;
-#endif
 
 	caio->cmpl_cnt++;
 	caio->res += numbytes;

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -3269,7 +3269,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 		sg = req->sg;
 		ep_addr = req->ep_addr + (req->offset & (aperture - 1));
 		i = req->sg_idx;
-		
+
 		for (sg = req->sg; i < sg_max && desc_idx < desc_max;
 			i++, sg = sg_next(sg)) {
 			dma_addr_t addr = sg_dma_address(sg);
@@ -3302,7 +3302,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 				ep_addr += len;
 				addr += len;
 				tlen -= len;
-				
+
 				desc_idx++;
 				desc_cnt++;
 				if (desc_idx == desc_max)
@@ -3314,7 +3314,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 			else
 				break;
 		}
-		
+
 		req->sg_offset = sg_offset;
 		req->sg_idx = i;
 
@@ -3523,7 +3523,6 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 #else
 		nents = dma_map_sg(&xdev->pdev->dev, sg, sgt->orig_nents, dir);
 #endif
-
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -4232,9 +4231,9 @@ static int set_dma_mask(struct pci_dev *pdev)
 	dbg_init("sizeof(dma_addr_t) == %ld\n", sizeof(dma_addr_t));
 	/* 64-bit addressing capability for XDMA? */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64))) 
+	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(64)))
 #else
-	if (!dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64))) 
+	if (!dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64)))
 #endif
 	{
 		/* query for DMA transfer */
@@ -4245,11 +4244,11 @@ static int set_dma_mask(struct pci_dev *pdev)
 #endif
 		/* use 64-bit DMA */
 		dbg_init("Using a 64-bit DMA mask.\n");
-	} else 
+	} else
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
-	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32))) 
+	if (!pci_set_dma_mask(pdev, DMA_BIT_MASK(32)))
 #else
-	if (!dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32))) 
+	if (!dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32)))
 #endif
 	{
 		dbg_init("Could not set 64-bit DMA mask.\n");

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,11 @@ fail:
 
 int xdma_cdev_init(void)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+#else
+	g_xdma_class = class_create(XDMA_NODE_NAME);
+#endif
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -111,7 +111,9 @@ struct cdev_async_io {
 	struct work_struct wrk_itm;
 	struct cdev_async_io *next;
 	ssize_t res;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	ssize_t res2;
+#endif
 	int err_cnt;
 };
 

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -111,9 +111,7 @@ struct cdev_async_io {
 	struct work_struct wrk_itm;
 	struct cdev_async_io *next;
 	ssize_t res;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 16, 0)
 	ssize_t res2;
-#endif
 	int err_cnt;
 };
 


### PR DESCRIPTION
Supersedes #179 and #150
Contains #210 

A few fixes for kernels 6.3 and 6.4.

Compiles on 6.5 as well.