### PR TITLE
[xdma] alonbl's stable patchset

### DIFF
--- a/XDMA/linux-kernel/tools/Makefile
+++ b/XDMA/linux-kernel/tools/Makefile
@@ -1,24 +1,38 @@
+prefix := /usr/local
+bindir := $(prefix)/bin
+PROGRAM_PREFIX :=
 CC ?= gcc
+CFLAGS ?=
+LDFLAGS ?=
+EXTRA_CFLAGS = -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+INSTALL ?= install
 
-all: reg_rw dma_to_device dma_from_device performance test_chrdev
+PROGRAMS = $(PROGRAM_PREFIX)reg_rw $(PROGRAM_PREFIX)dma_to_device $(PROGRAM_PREFIX)dma_from_device $(PROGRAM_PREFIX)performance $(PROGRAM_PREFIX)test_chrdev
 
-dma_to_device: dma_to_device.o
-	$(CC) -lrt -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+all: $(PROGRAMS)
 
-dma_from_device: dma_from_device.o
-	$(CC) -lrt -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+$(PROGRAM_PREFIX)dma_to_device: dma_to_device.o
+	$(CC) -lrt -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
-performance: performance.o
-	$(CC) -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+$(PROGRAM_PREFIX)dma_from_device: dma_from_device.o
+	$(CC) -lrt -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
-reg_rw: reg_rw.o
-	$(CC) -o $@ $<
+$(PROGRAM_PREFIX)performance: performance.o
+	$(CC) -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
-test_chrdev: test_chrdev.o
-	$(CC) -o $@ $<
+$(PROGRAM_PREFIX)reg_rw: reg_rw.o
+	$(CC) -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
+
+$(PROGRAM_PREFIX)test_chrdev: test_chrdev.o
+	$(CC) -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS) $(LDFLAGS)
 
 %.o: %.c
-	$(CC) -c -std=c99 -o $@ $< -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_LARGE_FILE_SOURCE
+	$(CC) -c -std=c99 -o $@ $< $(CFLAGS) $(EXTRA_CFLAGS)
 
 clean:
-	rm -rf reg_rw *.o *.bin dma_to_device dma_from_device performance test_chrdev
+	rm -rf *.o *.bin
+	rm -fr $(PROGRAMS)
+
+install: all
+	install -d -m 0755 "$(DESTDIR)$(bindir)"
+	install -m 0755 $(PROGRAMS) "$(DESTDIR)$(bindir)"

--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -33,8 +33,10 @@ ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o
 	obj-m := $(TARGET_MODULE).o
 else
-	BUILDSYSTEM_DIR:=/lib/modules/$(shell uname -r)/build
+	MODLIB:=/lib/modules/$(shell uname -r)
+	BUILDSYSTEM_DIR:=$(MODLIB)/build
 	PWD:=$(shell pwd)
+	DEPMOD:=depmod
 all :
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) modules
 
@@ -42,17 +44,19 @@ clean:
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) clean
 	@/bin/rm -f *.ko modules.order *.mod.c *.o *.o.ur-safe .*.o.cmd
 
-install: all
+install: modules_install
 	@rm -f /lib/modules/5.15.0-67-generic/extra/xdma.ko
-	@echo "installing kernel modules to /lib/modules/$(shell uname -r)/xdma ..."
-	@mkdir -p -m 755 /lib/modules/$(shell uname -r)/xdma
-	@install -v -m 644 *.ko /lib/modules/$(shell uname -r)/xdma
-	@depmod -a || true
+
+modules_install: all
+	@echo "installing kernel modules to $(MODLIB)/xdma ..."
+	@mkdir -p -m 755 $(MODLIB)/xdma
+	@install -v -m 644 *.ko $(MODLIB)/xdma
+	@$(DEPMOD) -a || true
 
 uninstall:
-	@echo "Un-installing /lib/modules/$(shell uname -r)/xdma ..."
-	@/bin/rm -rf /lib/modules/$(shell uname -r)/xdma
-	@depmod -a
+	@echo "Un-installing $(MODLIB)/xdma ..."
+	@/bin/rm -rf $(MODLIB)/xdma
+	@$(DEPMOD) -a || true
 
 
 

--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -18,7 +18,7 @@ $(warning XVC_FLAGS: $(XVC_FLAGS).)
 
 topdir := $(shell cd $(src)/.. && pwd)
 
-TARGET_MODULE:=xdma
+TARGET_MODULE:=xdma-chr
 
 EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
 ifeq ($(DEBUG),1)

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -195,9 +195,9 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	struct xdma_dev *xdev;
 	struct xdma_cdev *xcdev = (struct xdma_cdev *)file->private_data;
 	unsigned long off;
-	unsigned long phys;
+	resource_size_t phys;
 	unsigned long vsize;
-	unsigned long psize;
+	resource_size_t psize;
 	int rv;
 
 	rv = xcdev_check(__func__, xcdev, 0);

--- a/XDMA/linux-kernel/xdma/cdev_events.c
+++ b/XDMA/linux-kernel/xdma/cdev_events.c
@@ -59,7 +59,7 @@ static ssize_t char_events_read(struct file *file, char __user *buf,
 
 	/* wait_event_interruptible() was interrupted by a signal */
 	if (rv == -ERESTARTSYS)
-		return -ERESTARTSYS;
+		return -EAGAIN;
 
 	/* atomically decide which events are passed to the user */
 	spin_lock_irqsave(&user_irq->events_lock, flags);

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -37,13 +37,13 @@
 #include "xdma_thread.h"
 
 /* Module Parameters */
-unsigned int h2c_timeout = 10;
-module_param(h2c_timeout, uint, 0644);
-MODULE_PARM_DESC(h2c_timeout, "H2C sgdma timeout in seconds, default is 10 sec.");
+unsigned int h2c_timeout_ms = 10000;
+module_param(h2c_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(h2c_timeout_ms, "H2C sgdma timeout in milliseconds, default is 10 seconds.");
 
-unsigned int c2h_timeout = 10;
-module_param(c2h_timeout, uint, 0644);
-MODULE_PARM_DESC(c2h_timeout, "C2H sgdma timeout in seconds, default is 10 sec.");
+unsigned int c2h_timeout_ms = 10000;
+module_param(c2h_timeout_ms, uint, 0644);
+MODULE_PARM_DESC(c2h_timeout_ms, "C2H sgdma timeout in milliseconds, default is 10 seconds.");
 
 extern struct kmem_cache *cdev_cache;
 static void char_sgdma_unmap_user_buf(struct xdma_io_cb *cb, bool write);
@@ -90,8 +90,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 		numbytes = xdma_xfer_completion((void *)cb, xdev,
 				engine->channel, cb->write, cb->ep_addr,
 				&cb->sgt, 0, 
-				cb->write ? h2c_timeout * 1000 :
-					    c2h_timeout * 1000);
+				cb->write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(cb, cb->write);
 
@@ -416,8 +415,7 @@ static ssize_t char_sgdma_read_write(struct file *file, const char __user *buf,
 		return rv;
 
 	res = xdma_xfer_submit(xdev, engine->channel, write, *pos, &cb.sgt,
-				0, write ? h2c_timeout * 1000 :
-					   c2h_timeout * 1000);
+				0, write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(&cb, write);
 
@@ -500,7 +498,7 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
-					0, h2c_timeout * 1000);
+					0, h2c_timeout_ms);
 	}
 
 	if (engine->cmplthp)
@@ -574,7 +572,7 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
-					0, c2h_timeout * 1000);
+					0, c2h_timeout_ms);
 	}
 
 	if (engine->cmplthp)
@@ -821,8 +819,7 @@ static int ioctl_do_aperture_dma(struct xdma_engine *engine, unsigned long arg,
 
 	io.error = 0;
 	res = xdma_xfer_aperture(engine, write, io.ep_addr, io.aperture,
-				&cb.sgt, 0, write ? h2c_timeout * 1000 :
-						c2h_timeout * 1000);
+				&cb.sgt, 0, write ? h2c_timeout_ms : c2h_timeout_ms);
 
 	char_sgdma_unmap_user_buf(&cb, write);
 	if (res < 0)

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -4453,7 +4453,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 	/* allocate zeroed device book keeping structure */
 	xdev = alloc_dev_instance(pdev);
 	if (!xdev)
-		return NULL;
+		goto err_alloc_dev_instance;
 	xdev->mod_name = mname;
 	xdev->user_max = *user_max;
 	xdev->h2c_channel_max = *h2c_channel_max;
@@ -4472,12 +4472,12 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 
 	rv = xdev_list_add(xdev);
 	if (rv < 0)
-		goto free_xdev;
+		goto err_xdev_list_add;
 
 	rv = pci_enable_device(pdev);
 	if (rv) {
 		dbg_init("pci_enable_device() failed, %d.\n", rv);
-		goto err_enable;
+		goto err_pci_enable_device;
 	}
 
 	/* keep INTx enabled */
@@ -4500,15 +4500,15 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 
 	rv = request_regions(xdev, pdev);
 	if (rv)
-		goto err_regions;
+		goto err_request_regions;
 
 	rv = map_bars(xdev, pdev);
 	if (rv)
-		goto err_map;
+		goto err_map_bars;
 
 	rv = set_dma_mask(pdev);
 	if (rv)
-		goto err_mask;
+		goto err_set_dma_mask;
 
 	check_nonzero_interrupt_status(xdev);
 	/* explicitely zero all interrupt enable masks */
@@ -4518,15 +4518,15 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 
 	rv = probe_engines(xdev);
 	if (rv)
-		goto err_mask;
+		goto err_probe_engines;
 
 	rv = enable_msi_msix(xdev, pdev);
 	if (rv < 0)
-		goto err_engines;
+		goto err_enable_msi_msix;
 
 	rv = irq_setup(xdev, pdev);
 	if (rv < 0)
-		goto err_msix;
+		goto err_irq_setup;
 
 	if (!poll_mode)
 		channel_interrupts_enable(xdev, ~0);
@@ -4541,22 +4541,24 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev, int *user_max,
 	xdma_device_flag_clear(xdev, XDEV_FLAG_OFFLINE);
 	return (void *)xdev;
 
-err_msix:
+err_irq_setup:
 	disable_msi_msix(xdev, pdev);
-err_engines:
+err_enable_msi_msix:
 	remove_engines(xdev);
-err_mask:
+err_probe_engines:
+err_set_dma_mask:
 	unmap_bars(xdev, pdev);
-err_map:
+err_map_bars:
 	if (xdev->got_regions)
 		pci_release_regions(pdev);
-err_regions:
+err_request_regions:
 	if (!xdev->regions_in_use)
 		pci_disable_device(pdev);
-err_enable:
+err_pci_enable_device:
 	xdev_list_remove(xdev);
-free_xdev:
+err_xdev_list_add:
 	kfree(xdev);
+err_alloc_dev_instance:
 	return NULL;
 }
 

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -2330,12 +2330,7 @@ static void xdma_desc_link(struct xdma_desc *first, struct xdma_desc *second,
 /* xdma_desc_adjacent -- Set how many descriptors are adjacent to this one */
 static void xdma_desc_adjacent(struct xdma_desc *desc, u32 next_adjacent)
 {
-	/* remember reserved and control bits */
-	u32 control = le32_to_cpu(desc->control) & 0x0000f0ffUL;
-	/* merge adjacent and control field */
-	control |= 0xAD4B0000UL | (next_adjacent << 8);
-	/* write control and next_adjacent */
-	desc->control = cpu_to_le32(control);
+	desc->control = cpu_to_le32(le32_to_cpu(desc->control) | next_adjacent << 8);
 }
 
 /* xdma_desc_control -- Set complete control field of a descriptor. */

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -55,6 +55,32 @@ MODULE_PARM_DESC(desc_blen_max,
 
 #define XDMA_PERF_NUM_DESC 128
 
+/* Functions:
+   * wait_event_interruptible_timeout
+   * swait_event_interruptible_timeout_exclusive
+   * wait_event_interruptible
+   * swait_event_interruptible_exclusive
+   could return prematurely (-ERESTARTSYS) if interrupted by a signal, this case must be handled by kernel module */
+#define xlx_wait_event_interruptible_timeout(wq, condition, timeout) \
+({\
+	int __ret = 0;  \
+	unsigned long expire = timeout + jiffies; \
+	do { \
+		__ret = _xlx_wait_event_interruptible_timeout(wq, condition, \
+							timeout); \
+	} while ((__ret < 0) && (jiffies < expire)); \
+       __ret; \
+})
+
+#define xlx_wait_event_interruptible(wq, condition) \
+({\
+	int __ret = 0;  \
+	do { \
+		__ret = _xlx_wait_event_interruptible(wq, condition); \
+	} while (__ret < 0); \
+       __ret; \
+})
+
 /* Kernel version adaptative code */
 #if HAS_SWAKE_UP_ONE
 /* since 4.18, using simple wait queues is not recommended
@@ -62,31 +88,21 @@ MODULE_PARM_DESC(desc_blen_max,
  * and will likely be removed in future kernel versions
  */
 #define xlx_wake_up	swake_up_one
-#define xlx_wait_event_interruptible_timeout \
+#define _xlx_wait_event_interruptible_timeout \
 			swait_event_interruptible_timeout_exclusive
-#define xlx_wait_event_interruptible \
+#define _xlx_wait_event_interruptible \
 			swait_event_interruptible_exclusive
 #elif HAS_SWAKE_UP
 #define xlx_wake_up	swake_up
-#define xlx_wait_event_interruptible_timeout \
+#define _xlx_wait_event_interruptible_timeout \
 			swait_event_interruptible_timeout
-#define xlx_wait_event_interruptible \
+#define _xlx_wait_event_interruptible \
 			swait_event_interruptible
 #else
 #define xlx_wake_up	wake_up_interruptible
-/* wait_event_interruptible_timeout() could return prematurely (-ERESTARTSYS)
- * if it is interrupted by a signal */
-#define xlx_wait_event_interruptible_timeout(wq, condition, timeout) \
-({\
-	int __ret = 0;  \
-	unsigned long expire = timeout + jiffies; \
-	do { \
-		__ret = wait_event_interruptible_timeout(wq, condition, \
-							timeout); \
-	} while ((__ret < 0) && (jiffies < expire)); \
-       __ret; \
-})
-#define xlx_wait_event_interruptible \
+#define _xlx_wait_event_interruptible_timeout \
+           wait_event_interruptible_timeout
+#define _xlx_wait_event_interruptible \
 			wait_event_interruptible
 #endif
 

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -434,7 +434,7 @@ static void engine_status_dump(struct xdma_engine *engine)
 	char *buf = buffer;
 	int len = 0;
 
-	len = sprintf(buf, "SG engine %s status: 0x%08x: ", engine->name, v);
+	len = sprintf(buf, "SG engine %.16s status: 0x%08x: ", engine->name, v);
 
 	if ((v & XDMA_STAT_BUSY))
 		len += sprintf(buf + len, "BUSY,");

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1003,6 +1003,7 @@ engine_service_final_transfer(struct xdma_engine *engine,
 			WARN_ON(*pdesc_completed > transfer->desc_num);
 		}
 		/* mark transfer as successfully completed */
+		engine_service_shutdown(engine);
 		transfer->state = TRANSFER_STATE_COMPLETED;
 		transfer->desc_cmpl = transfer->desc_num;
 		/* add dequeued number of descriptors during this run */

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -31,7 +31,7 @@
 #include "xdma_cdev.h"
 #include "version.h"
 
-#define DRV_MODULE_NAME		"xdma"
+#define DRV_MODULE_NAME		"xdma-chr"
 #define DRV_MODULE_DESC		"Xilinx XDMA Reference Driver"
 
 static char version[] =

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -361,8 +361,8 @@ static int xdma_mod_init(void)
 
 	if (desc_blen_max > XDMA_DESC_BLEN_MAX)
 		desc_blen_max = XDMA_DESC_BLEN_MAX;
-	pr_info("desc_blen_max: 0x%x/%u, timeout: h2c %u c2h %u sec.\n",
-		desc_blen_max, desc_blen_max, h2c_timeout, c2h_timeout);
+	pr_info("desc_blen_max: 0x%x/%u, timeout: h2c %u c2h %u (ms)\n",
+		desc_blen_max, desc_blen_max, h2c_timeout_ms, c2h_timeout_ms);
 
 	rv = xdma_cdev_init();
 	if (rv < 0)

--- a/XDMA/linux-kernel/xdma/xdma_mod.h
+++ b/XDMA/linux-kernel/xdma/xdma_mod.h
@@ -55,8 +55,8 @@
 #define MAGIC_BITSTREAM 0xBBBBBBBBUL
 
 extern unsigned int desc_blen_max;
-extern unsigned int h2c_timeout;
-extern unsigned int c2h_timeout;
+extern unsigned int h2c_timeout_ms;
+extern unsigned int c2h_timeout_ms;
 
 struct xdma_cdev {
 	unsigned long magic;		/* structure ID for sanity checks */


### PR DESCRIPTION
Xilinx developers do not maintain the xdma driver and does not cooperate on github as well, I collected stable fixes of the xdma driver for people use and review.

WARNING: The xdma driver is far from being production grade, it crashes the kernel when aio is used,  [crashes](https://github.com/Xilinx/dma_ip_drivers/issues/113) when readv/writev is used, it have fundamental issues that are solved in this series, it loses sync at random time splitting buffers into parts, it also does not respect small buffer boundary.

XDMA DMA engine was merged into mainline since linux-6.3, staging is at https://git.kernel.org/pub/scm/linux/kernel/git/vkoul/dmaengine.git/tree/drivers/dma/xilinx/xdma.c a user bridge is missing so we can switch.

The following patchset at least provides some sanity for EOP and stream based synchronous continues allocation operations.

Thanks for all contributors.

**Notice**

The name of the module is renamed from `xdma.ko` to `xdma-chr.ko` due to a conflict with latest merge of `xdma.ko` dmaengine into upstream.

**Patchset includes**

|Merged|Reference|Description|
|-|-|-|
| |        |xdma: rename module to xdma-chr|
| |        |xdma: build improvements|
|?|#319|xdma: cdev_events: Do not leak ERESTARTSYS leak to userspace|
| |#144|xdma: explicitly stop engine on transfer completion|
|V|#161|xdma: fix decs_cmpl and flush when eop received|
|V|#190|xdma: fixed PCIe domain and bus values in info ioctl|
| |#92 |xdma: simplify next_adj setting|
| |#158|xmda: set module parameter timeouts as milliseconds|
| |#313|xdma: libxdma: handle ERESTARTSYS for both wait_ and swait_*, with and without timeout|
|V|#315|xdma: libxdma: engine_status_dump: avoid buffer overflow|
| |        |xdma: libxdma: fix resource free on open|
| |#226|xdma: cdev_ctrl: use resource_size_t for pci_resource_start()|
|V|#218|xdma: correct typos in xdma_mod.c|
| |        |libxdma: improve messages|
|V|#315|libxdma: fix message typo|
