### PR TITLE
Improved DMA adjacency descriptor prefetch function in performance mode

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -4081,6 +4081,22 @@ int xdma_performance_submit(struct xdma_dev *xdev, struct xdma_engine *engine)
 		pr_err("Failed to set desc control\n");
 		goto err_dma_desc;
 	}
+
+	/************ support prefetching adjacent descriptors -- start ************/
+
+	/* fill in adjacent numbers */
+	transfer->desc_adjacent = transfer->desc_num - 1;
+
+	for (i = 0; i < transfer->desc_num; i++) {
+		u32 next_adj = xdma_get_next_adj(transfer->desc_num - i - 1,
+						(transfer->desc_virt + i)->next_lo);
+
+		xdma_desc_adjacent(transfer->desc_virt + i, next_adj);
+		dbg_desc("prefetch: dma desc addr: %x_%x, control:%x", transfer->desc_virt[i].next_hi, transfer->desc_virt[i].next_lo, transfer->desc_virt[i].control);
+	}
+
+	/************ support prefetching adjacent descriptors -- end ************/
+
 	/* create a linked loop */
 	xdma_desc_link(transfer->desc_virt + transfer->desc_num - 1,
 		       transfer->desc_virt, transfer->desc_bus);


### PR DESCRIPTION
- **Question**
  In the performance monitoring mode (i.e., when running the perform_hwcount.sh script), the data transmission rate measured through experiments is significantly lower than what is demonstrated in the official Xilinx example (see video link: https://www.youtube.com/watch?v=WcEvAvtXL94). This discrepancy is particularly evident when transmitting data packets ranging from 0 to 4K in size.
- **Debugging**
  During debugging, the issue was traced back to the driver's lack of DMA descriptor prefetch functionality. Specifically, within the `libxdma.c` file's `xdma_performance_submit` function, the filling of the adjacent descriptor count field was not implemented. This results in XDMA operating inefficiently by fetching descriptors one by one instead of retrieving multiple adjacent descriptors at once.
- **Solution**
    The relevant adjacent descriptor counting logic code has been added to the xdma_performance_submit function in libxdma.c, as follows:
    ```c
	  /* fill in adjacent numbers */
	  transfer->desc_adjacent = transfer->desc_num - 1;
  
	  for (i = 0; i < transfer->desc_num; i++) {
		  u32 next_adj = xdma_get_next_adj(transfer->desc_num - i - 1,
						  (transfer->desc_virt + i)->next_lo);
  
		  xdma_desc_adjacent(transfer->desc_virt + i, next_adj);
		  dbg_desc("prefetch: dma desc addr: %x_%x, control:%x", transfer->desc_virt[i].next_hi, transfer->desc_virt[i].next_lo, transfer->desc_virt[i].control);
	  }
    ```
- **Result**
![desc_prefetch](https://github.com/Xilinx/dma_ip_drivers/assets/43944845/7944233f-9d4b-438b-bb94-ee3312fe42c6)

