### PR TITLE
XDMA: Remove reference to Vhost_scsi_map_to_sgl

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -232,7 +232,6 @@ static int check_transfer_align(struct xdma_engine *engine,
 
 /*
  * Map a user memory range into a scatterlist
- * inspired by vhost_scsi_map_to_sgl()
  * Returns the number of scatterlist entries used or -errno on error.
  */
 static inline void xdma_io_cb_release(struct xdma_io_cb *cb)


### PR DESCRIPTION
Code is neither copied nor re-used from Vhost_scsi_map_to_sgl() function, hence removing reference.