### PR TITLE
QDMA: Limit descriptor length for EQDMA Soft IP

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/xdev.h
+++ b/QDMA/linux-kernel/driver/libqdma/xdev.h
@@ -95,6 +95,18 @@ enum qdma_pf_devices {
  */
 #define QDMA_DESC_BLEN_MAX	((1 << (QDMA_DESC_BLEN_BITS)) - 1)
 
+#ifdef __XRT__
+/**
+ * number of bits to describe the SOFT DMA transfer descriptor
+ */
+#define SOFT_QDMA_DESC_BLEN_BITS   15
+
+/**
+ * maximum size of a single SOFT DMA transfer descriptor
+ */
+#define SOFT_QDMA_DESC_BLEN_MAX      (1 << (SOFT_QDMA_DESC_BLEN_BITS))
+#endif
+
 /**
  * obtain the 32 most significant (high) bits of a 32-bit or 64-bit address
  */


### PR DESCRIPTION
EQDMA Soft 5.0 IP is designed to do only 64Kb-1 data transfer per descriptor. So, limiting the descriptor length to 32Kb.