### PR TITLE
some changes in linux kernel6.5.0/ubuntu22.04

### DIFF
--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -27,7 +27,7 @@ endif
 ifneq ($(config_bar_num),)
 	EXTRA_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
 endif
-#EXTRA_CFLAGS += -DINTERNAL_TESTING
+# EXTRA_CFLAGS += -DINTERNAL_TESTING
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,7 +233,11 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	vm_flags_set(vma, VMEM_FLAGS);
+#else
 	vma->vm_flags |= VMEM_FLAGS;
+#endif
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,7 +233,15 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
+<<<<<<< HEAD
 	//vma->vm_flags |= VMEM_FLAGS; // error: assignment of read-only member ‘vm_flags’
+=======
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	vm_flags_set(vma, VMEM_FLAGS);
+#else
+	vma->vm_flags |= VMEM_FLAGS;
+#endif
+>>>>>>> eaf78c5 (some change in linux kernel6.5.0)
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,7 +233,7 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
-	vma->vm_flags |= VMEM_FLAGS;
+	//vma->vm_flags |= VMEM_FLAGS; // error: assignment of read-only member ‘vm_flags’
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -565,12 +565,12 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -565,28 +565,20 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-<<<<<<< HEAD
-	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
-=======
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
 #else
 	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
 #endif
->>>>>>> eaf78c5 (some change in linux kernel6.5.0)
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
-<<<<<<< HEAD
-	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
-=======
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
 #else
 	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
 #endif
->>>>>>> eaf78c5 (some change in linux kernel6.5.0)
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -109,7 +109,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 		caio->iocb->ki_complete(caio->iocb, res, res2);
 #else
-		aio_complete(caio->iocb, res, res2);
+		aio_complete(caio->iocb, res, caio->res2);
 #endif
 skip_tran:
 		spin_unlock(&caio->lock);
@@ -565,12 +565,28 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+<<<<<<< HEAD
 	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
+=======
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
+#else
+	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
+>>>>>>> eaf78c5 (some change in linux kernel6.5.0)
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+<<<<<<< HEAD
 	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
+=======
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
+#else
+	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
+>>>>>>> eaf78c5 (some change in linux kernel6.5.0)
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -109,7 +109,7 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
 		caio->iocb->ki_complete(caio->iocb, res, res2);
 #else
-		aio_complete(caio->iocb, res, res2);
+		aio_complete(caio->iocb, res, caio->res2);
 #endif
 skip_tran:
 		spin_unlock(&caio->lock);
@@ -565,12 +565,20 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_write(iocb, io->__iov, io->nr_segs, io->iov_offset);
+#else
 	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	return cdev_aio_read(iocb, io->__iov, io->nr_segs, io->iov_offset);
+#else
 	return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+#endif
 }
 #endif
 

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,11 @@ fail:
 
 int xdma_cdev_init(void)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
 	g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+#else
+	g_xdma_class = class_create(XDMA_NODE_NAME);
+#endif
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,7 @@ fail:
 
 int xdma_cdev_init(void)
 {
-	g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+	g_xdma_class = class_create(XDMA_NODE_NAME); //error: too many arguments to function ‘class_create’ | struct class * __must_check class_create(const char *name);
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,15 @@ fail:
 
 int xdma_cdev_init(void)
 {
+<<<<<<< HEAD
 	g_xdma_class = class_create(XDMA_NODE_NAME); //error: too many arguments to function ‘class_create’ | struct class * __must_check class_create(const char *name);
+=======
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+	g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+#else
+	g_xdma_class = class_create(XDMA_NODE_NAME);
+#endif
+>>>>>>> eaf78c5 (some change in linux kernel6.5.0)
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;


### PR DESCRIPTION
1.class_create() only need 1 parameter.
struct class * __must_check class_create(const char *name);
2. io->iov  should be io->__iov 
3. vma->vm_flags is read-only.