### PR TITLE
XDMA: Add lseek() to all interfaces and add sanity checks for addresses

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_bypass.c
+++ b/XDMA/linux-kernel/xdma/cdev_bypass.c
@@ -190,6 +190,7 @@ static const struct file_operations bypass_fops = {
 	.read = char_bypass_read,
 	.write = char_bypass_write,
 	.mmap = bridge_mmap,
+	.llseek = char_llseek,
 };
 
 void cdev_bypass_init(struct xdma_cdev *xcdev)

--- a/XDMA/linux-kernel/xdma/cdev_bypass.c
+++ b/XDMA/linux-kernel/xdma/cdev_bypass.c
@@ -81,6 +81,11 @@ static ssize_t char_bypass_read(struct file *file, char __user *buf,
 
 	dbg_sg("In %s()\n", __func__);
 
+	/*sanity checks for offsets*/
+	rc=position_check(xdev->bar_size[xcdev->bar], *pos, engine->addr_align);
+	if (rc < 0)
+		return rc;	
+
 	if (count & 3) {
 		dbg_sg("Buffer size must be a multiple of 4 bytes\n");
 		return -EINVAL;
@@ -132,7 +137,11 @@ static ssize_t char_bypass_write(struct file *file, const char __user *buf,
 		return rc;
 	xdev = xcdev->xdev;
 	engine = xcdev->engine;
-
+	
+	/*sanity checks for offsets*/
+	rc=position_check(xdev->bar_size[xcdev->bar], *pos, engine->addr_align);
+	if (rc < 0)
+		return rc;
 	if (count & 3) {
 		dbg_sg("Buffer size must be a multiple of 4 bytes\n");
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -46,10 +46,10 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 	if (rv < 0)
 		return rv;
 	xdev = xcdev->xdev;
-
-	/* only 32-bit aligned and 32-bit multiples */
-	if (*pos & 3)
-		return -EPROTO;
+	/*sanity checks for offsets*/
+	rv=position_check(xdev->bar_size[xcdev->bar], *pos, 4);
+	if (rv < 0)
+		return rv;
 	/* first address is BAR base plus file position offset */
 	reg = xdev->bar[xcdev->bar] + *pos;
 	//w = read_register(reg);
@@ -77,10 +77,10 @@ static ssize_t char_ctrl_write(struct file *file, const char __user *buf,
 	if (rv < 0)
 		return rv;
 	xdev = xcdev->xdev;
-
-	/* only 32-bit aligned and 32-bit multiples */
-	if (*pos & 3)
-		return -EPROTO;
+	/*sanity checks for offsets*/
+	rv=position_check(xdev->bar_size[xcdev->bar], *pos, 4);
+	if (rv < 0)
+		return rv;
 
 	/* first address is BAR base plus file position offset */
 	reg = xdev->bar[xcdev->bar] + *pos;

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -256,6 +256,7 @@ static const struct file_operations ctrl_fops = {
 	.write = char_ctrl_write,
 	.mmap = bridge_mmap,
 	.unlocked_ioctl = char_ctrl_ioctl,
+	.llseek = char_llseek,
 };
 
 void cdev_ctrl_init(struct xdma_cdev *xcdev)

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -135,35 +135,7 @@ skip_dev_lock:
 /*
  * character device file operations for SG DMA engine
  */
-static loff_t char_sgdma_llseek(struct file *file, loff_t off, int whence)
-{
-	loff_t newpos = 0;
 
-	switch (whence) {
-	case 0: /* SEEK_SET */
-		newpos = off;
-		break;
-	case 1: /* SEEK_CUR */
-		newpos = file->f_pos + off;
-		break;
-	case 2: /* SEEK_END, @TODO should work from end of address space */
-		newpos = UINT_MAX + off;
-		break;
-	default: /* can't happen */
-		return -EINVAL;
-	}
-	if (newpos < 0)
-		return -EINVAL;
-	file->f_pos = newpos;
-	dbg_fops("%s: pos=%lld\n", __func__, (signed long long)newpos);
-
-#if 0
-	pr_err("0x%p, off %lld, whence %d -> pos %lld.\n",
-		file, (signed long long)off, whence, (signed long long)off);
-#endif
-
-	return newpos;
-}
 
 /* char_sgdma_read_write() -- Read from or write to the device
  *
@@ -904,7 +876,7 @@ static const struct file_operations sgdma_fops = {
 	.aio_read = cdev_aio_read,
 #endif
 	.unlocked_ioctl = char_sgdma_ioctl,
-	.llseek = char_sgdma_llseek,
+	.llseek = char_llseek,
 };
 
 void cdev_sgdma_init(struct xdma_cdev *xcdev)

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -350,7 +350,10 @@ static ssize_t char_sgdma_read_write(struct file *file, const char __user *buf,
 			write, engine->dir);
 		return -EINVAL;
 	}
-
+	/*sanity checks for offsets. alignment check is redundunt, but doesn't hurt*/
+	rv=position_check(xdev->bar_size[xcdev->bar], *pos, engine->addr_align);
+	if (rv < 0)
+		return rv;
 	rv = check_transfer_align(engine, buf, count, *pos, 1);
 	if (rv) {
 		pr_info("Invalid transfer alignment detected\n");

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1729,7 +1729,7 @@ static int map_bars(struct xdma_dev *xdev, struct pci_dev *dev)
 			rv = -EINVAL;
 			goto fail;
 		}
-
+		xdev->bar_size[i] = bar_len;
 		/* Try to identify BAR as XDMA control BAR */
 		if ((bar_len >= XDMA_BAR_SIZE) && (xdev->config_bar_idx < 0)) {
 			if (is_config_bar(xdev, i)) {

--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -593,6 +593,7 @@ struct xdma_dev {
 
 	/* PCIe BAR management */
 	void __iomem *bar[XDMA_BAR_NUM];	/* addresses for mapped BARs */
+	loff_t bar_size[XDMA_BAR_NUM];		/* mapped size of BARs	*/ 
 	int user_bar_idx;	/* BAR index of user logic */
 	int config_bar_idx;	/* BAR index of XDMA config logic */
 	int bypass_bar_idx;	/* BAR index of XDMA bypass logic */

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -177,6 +177,36 @@ int char_open(struct inode *inode, struct file *file)
 	return 0;
 }
 
+loff_t char_llseek(struct file *file, loff_t off, int whence)
+{
+	loff_t newpos = 0;
+
+	switch (whence) {
+	case 0: /* SEEK_SET */
+		newpos = off;
+		break;
+	case 1: /* SEEK_CUR */
+		newpos = file->f_pos + off;
+		break;
+	case 2: /* SEEK_END, @TODO should work from end of address space */
+		newpos = UINT_MAX + off;
+		break;
+	default: /* can't happen */
+		return -EINVAL;
+	}
+	if (newpos < 0)
+		return -EINVAL;
+	file->f_pos = newpos;
+	dbg_fops("%s: pos=%lld\n", __func__, (signed long long)newpos);
+
+#if 0
+	pr_err("0x%p, off %lld, whence %d -> pos %lld.\n",
+		file, (signed long long)off, whence, (signed long long)off);
+#endif
+
+	return newpos;
+}
+
 /*
  * Called when the device goes from used to unused.
  */

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -159,6 +159,26 @@ int xcdev_check(const char *fname, struct xdma_cdev *xcdev, bool check_engine)
 
 	return 0;
 }
+//implementation of common sanity checks for file offset (position)
+int position_check(loff_t bar_size, loff_t pos, loff_t align)
+{
+	if (unlikely(pos < 0))
+	{	
+		pr_err("Negative address %lld\n", pos);
+		return -EINVAL;
+	}
+	if (unlikely(pos >= bar_size))
+	{
+		pr_err("Attempted to access address 0x%llx (%lld) that exceeds mapped BAR space size of %lld\n", pos, pos, bar_size);
+		return -ENXIO;
+	}
+	if (unlikely(pos & (align - 1)))
+	{	
+		pr_crit("Address 0x%llx (%lld) is not aligned to %lld bytes\n", pos, pos, align); 
+		return -EPROTO;
+	}
+	return 0;
+}
 
 int char_open(struct inode *inode, struct file *file)
 {

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -179,6 +179,8 @@ int char_open(struct inode *inode, struct file *file)
 
 loff_t char_llseek(struct file *file, loff_t off, int whence)
 {
+	struct xdma_cdev *xcdev = (struct xdma_cdev *)(file->private_data);
+	struct xdma_dev *xdev = xcdev->xdev;
 	loff_t newpos = 0;
 
 	switch (whence) {
@@ -188,8 +190,8 @@ loff_t char_llseek(struct file *file, loff_t off, int whence)
 	case 1: /* SEEK_CUR */
 		newpos = file->f_pos + off;
 		break;
-	case 2: /* SEEK_END, @TODO should work from end of address space */
-		newpos = UINT_MAX + off;
+	case 2: /* SEEK_END*/
+		newpos = xdev->bar_size[xcdev->bar]  + off;
 		break;
 	default: /* can't happen */
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/xdma_cdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.h
@@ -34,6 +34,7 @@ void xdma_cdev_cleanup(void);
 int xdma_cdev_init(void);
 
 int char_open(struct inode *inode, struct file *file);
+loff_t char_llseek(struct file *file, loff_t off, int whence);
 int char_close(struct inode *inode, struct file *file);
 int xcdev_check(const char *fname, struct xdma_cdev *xcdev, bool check_engine);
 void cdev_ctrl_init(struct xdma_cdev *xcdev);

--- a/XDMA/linux-kernel/xdma/xdma_cdev.h
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.h
@@ -37,6 +37,7 @@ int char_open(struct inode *inode, struct file *file);
 loff_t char_llseek(struct file *file, loff_t off, int whence);
 int char_close(struct inode *inode, struct file *file);
 int xcdev_check(const char *fname, struct xdma_cdev *xcdev, bool check_engine);
+int position_check(loff_t bar_size, loff_t pos, loff_t align);
 void cdev_ctrl_init(struct xdma_cdev *xcdev);
 void cdev_xvc_init(struct xdma_cdev *xcdev);
 void cdev_event_init(struct xdma_cdev *xcdev);


### PR DESCRIPTION
[XDMA driver doesn't implement lseek for AXI Lite interface](https://github.com/Xilinx/dma_ip_drivers/issues/96), which is not only completely illogical, because it is supposed to set the AXI addresses, but potentially problematic, because since version 6.0 Linux kernel  no longer checks for null f_ops.

This pull request adds an implementation of `lseek` to all interface types. Additionally, `SEEK_END` properly sets address from the end of the address space. This was done by adding suitable entry to the`xdma_dev` structure.

This allowed to consolidate and add sanity checks for addresses that:

- Are negative. Despite already present check in lseek, it is still possible to try to pass it with `pwrite\pread`.
- Lie beyond (mapped BAR) address space. Current version allows access to arbitrary addresses, which can wreak havoc in the kernel log.
- are not correctly aligned. The checks are now consolidated in a common function

Please have a look, because I am not a Linux kernel driver expert, and also test for memory-mapped DMA and AXI Bridge (so called DMA Bypass)