### PR TITLE
XDMA: Add support for AlmaOS 9.4 and ubuntu 24.04

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,7 +233,11 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
-	vma->vm_flags |= VMEM_FLAGS;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+        vm_flags_set(vma, VMEM_FLAGS);
+#else
+        vma->vm_flags |= VMEM_FLAGS;
+#endif
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,
 			vsize, vma->vm_page_prot);

--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -483,7 +483,11 @@ struct xdma_request_cb {
 
 	unsigned int sw_desc_idx;
 	unsigned int sw_desc_cnt;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+        struct sw_desc sdesc[];
+#else
 	struct sw_desc sdesc[0];
+#endif
 };
 
 struct xdma_engine {

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -603,7 +603,17 @@ fail:
 
 int xdma_cdev_init(void)
 {
-	g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+#if defined(RHEL_RELEASE_CODE)
+    #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+        g_xdma_class = class_create(XDMA_NODE_NAME);
+    #else
+        g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+    #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+        g_xdma_class = class_create(XDMA_NODE_NAME);
+#else
+        g_xdma_class = class_create(THIS_MODULE, XDMA_NODE_NAME);
+#endif
 	if (IS_ERR(g_xdma_class)) {
 		dbg_init(XDMA_NODE_NAME ": failed to create class");
 		return -EINVAL;

--- a/XDMA/linux-kernel/xdma/xdma_thread.h
+++ b/XDMA/linux-kernel/xdma/xdma_thread.h
@@ -144,4 +144,6 @@ void xdma_thread_remove_work(struct xdma_engine *engine);
  *****************************************************************************/
 void xdma_thread_add_work(struct xdma_engine *engine);
 
+int xdma_kthread_start(struct xdma_kthread *thp, char *name, int id);
+int xdma_kthread_stop(struct xdma_kthread *thp);
 #endif /* #ifndef __XDMA_KTHREAD_H__ */


### PR DESCRIPTION
Added support in XDMA drivers to compile on Ubuntu 24.04 and AlmaLinux 9.4.Validated with latest bitstreams for MM and ST provided for XDMA gen3x16 on VCU118.