### PR TITLE
Always print "Engine was not running!!! Clearing status\n" message

### DIFF
--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -1109,7 +1109,7 @@ static int engine_service(struct xdma_engine *engine, int desc_writeback)
 
 	/* Service the engine */
 	if (!engine->running) {
-		dbg_tfr("Engine was not running!!! Clearing status\n");
+		pr_err("Engine was not running!!! Clearing status\n");
 		rv = engine_status_read(engine, 1, 0);
 		if (rv < 0) {
 			pr_err("%s failed to read status\n", engine->name);


### PR DESCRIPTION
Always (i.e. don't require a build with LIBXDMA_DEBUG flag) print "Engine was not running!!! Clearing status\n" message as it simplifies diagnostics. Fixes #312