### PR TITLE
Fix ERESTARTSYS leak to userspace

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_events.c
+++ b/XDMA/linux-kernel/xdma/cdev_events.c
@@ -59,7 +59,7 @@ static ssize_t char_events_read(struct file *file, char __user *buf,
 
 	/* wait_event_interruptible() was interrupted by a signal */
 	if (rv == -ERESTARTSYS)
-		return -ERESTARTSYS;
+		return -EAGAIN;
 
 	/* atomically decide which events are passed to the user */
 	spin_lock_irqsave(&user_irq->events_lock, flags);

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -3428,7 +3428,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 			transfer_dump(xfer);
 			sgt_dump(sgt);
 #endif
-			rv = -ERESTARTSYS;
+			rv = -ETIMEDOUT;
 			break;
 		}
 
@@ -3658,7 +3658,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			transfer_dump(xfer);
 			sgt_dump(sgt);
 #endif
-			rv = -ERESTARTSYS;
+			rv = -ETIMEDOUT;
 			break;
 		}
 
@@ -3789,7 +3789,7 @@ ssize_t xdma_xfer_completion(void *cb_hndl, void *dev_hndl, int channel,
 			transfer_dump(xfer);
 			sgt_dump(sgt);
 #endif
-			rv = -ERESTARTSYS;
+			rv = -ETIMEDOUT;
 			break;
 		}
 


### PR DESCRIPTION
Fix ERESTARTSYS leak to userspace by replacing it with the appropriate for userspace error codes. Fixes #320