### PR TITLE
Do not use FIELD_GET since c structure access is enough

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
@@ -3033,14 +3033,10 @@ static int qdma_cpm4_cmpt_context_write(void *dev_hndl, uint16_t hw_qid,
 	}
 
 	if ((ctxt->higher_dword.bit.desc_sz > QDMA_DESC_SIZE_32B) ||
-		(FIELD_GET(CMPL_CTXT_DATA_W0_QSIZE_IDX_MASK,
-		ctxt->lower_dword.bit.ringsz_idx) >= QDMA_NUM_RING_SIZES) ||
-		(FIELD_GET(CMPL_CTXT_DATA_W0_CNTER_IDX_MASK,
-		ctxt->lower_dword.bit.counter_idx) >= QDMA_NUM_C2H_COUNTERS) ||
-		(FIELD_GET(CMPL_CTXT_DATA_W0_TIMER_IDX_MASK,
-		ctxt->lower_dword.bit.timer_idx) >= QDMA_NUM_C2H_TIMERS) ||
-		(ctxt->lower_dword.bit.trig_mode >
-		QDMA_CMPT_UPDATE_TRIG_MODE_TMR_CNTR)) {
+		(ctxt->lower_dword.bit.ringsz_idx >= QDMA_NUM_RING_SIZES) ||
+		(ctxt->lower_dword.bit.counter_idx >= QDMA_NUM_C2H_COUNTERS) ||
+		(ctxt->lower_dword.bit.timer_idx >= QDMA_NUM_C2H_TIMERS) ||
+		(ctxt->lower_dword.bit.trig_mode > QDMA_CMPT_UPDATE_TRIG_MODE_TMR_CNTR)) {
 		qdma_log_error
 		("%s Inv dsz(%d)/ridx(%d)/cntr(%d)/tmr(%d)/tm(%d), err:%d\n",
 				__func__,


### PR DESCRIPTION
gcc 14 was reporting an error. This is the correct fix for all versions.