### PR TITLE
Resolve build errors for QDMA and XDMA on recent kernel version

### DIFF
--- a/QDMA/linux-kernel/driver/Makefile
+++ b/QDMA/linux-kernel/driver/Makefile
@@ -135,7 +135,7 @@ endif
 MAKEOVERRIDES := $(filter-out ARCH=%,$(MAKEOVERRIDES))
 # Don't allow CFLAGS/EXTRA_CFLAGS to clobber definitions in sub-make.
 MAKEOVERRIDES := $(filter-out CFLAGS=%,$(MAKEOVERRIDES))
-MAKEOVERRIDES := $(filter-out EXTRA_CFLAGS=%,$(MAKEOVERRIDES))
+MAKEOVERRIDES := $(filter-out ccflags-y=%,$(MAKEOVERRIDES))
 
 # Exports.
 export grep

--- a/QDMA/linux-kernel/driver/libqdma/Makefile
+++ b/QDMA/linux-kernel/driver/libqdma/Makefile
@@ -35,13 +35,13 @@ include $(srcdir)/../make_rules/common_flags.mk
 $(info srcdir = $(srcdir).)
 $(info KSRC = $(KSRC).)
 
-EXTRA_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
-EXTRA_CFLAGS += $(FLAGS) $(CPPFLAGS)
-EXTRA_CFLAGS += -I$(srcdir)/../include
-EXTRA_CFLAGS += -I$(KSRC)/../include
-EXTRA_CFLAGS += -I.
+ccflags-y += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
+ccflags-y += $(FLAGS) $(CPPFLAGS)
+ccflags-y += -I$(srcdir)/../include
+ccflags-y += -I$(KSRC)/../include
+ccflags-y += -I.
 
-#EXTRA_CFLAGS += -DDEBUG
+#ccflags-y += -DDEBUG
 
 ifneq ($(modulesymfile),)
   override symverfile = symverfile="$(topdir)/$(modulesymfile) \

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.h
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_access_common.h
@@ -22,6 +22,11 @@
 extern "C" {
 #endif
 
+#include <linux/version.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+#include <linux/bitfield.h>
+#endif
+
 #include "qdma_access_export.h"
 #include "qdma_access_errors.h"
 
@@ -71,7 +76,9 @@ static inline uint32_t get_trailing_zeros(uint64_t value)
 
 #define FIELD_SHIFT(mask)       get_trailing_zeros(mask)
 #define FIELD_SET(mask, val)    ((val << FIELD_SHIFT(mask)) & mask)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
 #define FIELD_GET(mask, reg)    ((reg & mask) >> FIELD_SHIFT(mask))
+#endif
 
 
 /* CSR Default values */

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
@@ -3033,12 +3033,9 @@ static int qdma_cpm4_cmpt_context_write(void *dev_hndl, uint16_t hw_qid,
 	}
 
 	if ((ctxt->higher_dword.bit.desc_sz > QDMA_DESC_SIZE_32B) ||
-		(FIELD_GET(CMPL_CTXT_DATA_W0_QSIZE_IDX_MASK,
-		ctxt->lower_dword.bit.ringsz_idx) >= QDMA_NUM_RING_SIZES) ||
-		(FIELD_GET(CMPL_CTXT_DATA_W0_CNTER_IDX_MASK,
-		ctxt->lower_dword.bit.counter_idx) >= QDMA_NUM_C2H_COUNTERS) ||
-		(FIELD_GET(CMPL_CTXT_DATA_W0_TIMER_IDX_MASK,
-		ctxt->lower_dword.bit.timer_idx) >= QDMA_NUM_C2H_TIMERS) ||
+		(ctxt->lower_dword.bit.ringsz_idx >= QDMA_NUM_RING_SIZES) ||
+		(ctxt->lower_dword.bit.counter_idx >= QDMA_NUM_C2H_COUNTERS) ||
+		(ctxt->lower_dword.bit.timer_idx >= QDMA_NUM_C2H_TIMERS) ||
 		(ctxt->lower_dword.bit.trig_mode >
 		QDMA_CMPT_UPDATE_TRIG_MODE_TMR_CNTR)) {
 		qdma_log_error

--- a/QDMA/linux-kernel/driver/libqdma/thread.c
+++ b/QDMA/linux-kernel/driver/libqdma/thread.c
@@ -38,8 +38,7 @@ int qdma_kthread_dump(struct qdma_kthread *thp, char *buf, int buflen,
 	len += snprintf(buf, buflen, "%s, cpu %u, work %u.\n",
 			thp->name, thp->cpu, thp->work_cnt);
 
-	if (detail)
-		;
+	(void)detail;
 
 	unlock_thread(thp);
 

--- a/QDMA/linux-kernel/driver/src/Makefile
+++ b/QDMA/linux-kernel/driver/src/Makefile
@@ -44,15 +44,15 @@ $(info ARCH = $(ARCH).)
 
 MOD_NAME := qdma$(PFVF_TYPE)
 
-EXTRA_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
-EXTRA_CFLAGS += $(FLAGS) $(CPPFLAGS) $(EXTRA_FLAGS)
-EXTRA_CFLAGS += -I$(srcdir)/../include
-EXTRA_CFLAGS += -I$(KSRC)/../include
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_soft_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_soft_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_cpm5_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_cpm4_access
-EXTRA_CFLAGS += -I.
+ccflags-y += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
+ccflags-y += $(FLAGS) $(CPPFLAGS) $(EXTRA_FLAGS)
+ccflags-y += -I$(srcdir)/../include
+ccflags-y += -I$(KSRC)/../include
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/qdma_soft_access
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/eqdma_soft_access
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/eqdma_cpm5_access
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/qdma_cpm4_access
+ccflags-y += -I.
 
 # linux >= 3.13 genl_ops become part of the genl_family. And although
 # genl_register_family_with_ops() is still retained until kernel 4.10,
@@ -82,7 +82,7 @@ endif
 
 $(info EXTRA_FLAGS = $(EXTRA_FLAGS).)
 $(info ccflags-y = $(ccflags-y).)
-#EXTRA_CFLAGS += -DDEBUG
+#ccflags-y += -DDEBUG
 
 #For Kernel Images > 4.9.199 with CONFIG_STACK_VALIDATION=y and GCC version > 8 compiler throws spurious warnings
 #related to sibling calls and frame pointer save/setup. To supress these warnings

--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -20,14 +20,14 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
+ccflags-y := -I$(topdir)/include $(XVC_FLAGS)
 ifeq ($(DEBUG),1)
-	EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
+	ccflags-y += -D__LIBXDMA_DEBUG__
 endif
 ifneq ($(config_bar_num),)
-	EXTRA_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
+	ccflags-y += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
 endif
-#EXTRA_CFLAGS += -DINTERNAL_TESTING
+#ccflags-y += -DINTERNAL_TESTING
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o


### PR DESCRIPTION
### Descripton
This PR addresses build errors introduced by Kbuild changes and stricter type-checking in Linux kernel 6.15.

### Changes
- Kbuild: Switched from EXTRA_CFLAGS to ccflags-y (Fixes missing include paths/macros in v6.15+).
- Bitfields: Resolved FIELD_GET redefinition by using standard <linux/bitfield.h> for v6.15 and above.
- Type Safety: Removed redundant FIELD_GET calls on already-extracted bitfields to fix typeof() validation errors in the latest kernel headers.
- Empty body if statement:  Resolve empty-body error

### Environment
Tested on: 6.17.0-14-generic (ubuntu 24.04)