### PR TITLE
xdma: fix target address (ep_addr) mismatch in iter-based I/O

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -585,32 +585,38 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
 static ssize_t cdev_write_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+	loff_t pos = iocb->ki_pos;
+	ssize_t ret;
 #if defined(RHEL_RELEASE_CODE)
-        #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
-            return cdev_aio_write(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
-        #else
-            return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
-        #endif
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
-        return cdev_aio_write(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+	ret = cdev_aio_write(iocb, iter_iov(io), io->nr_segs, pos);
 #else
-	return cdev_aio_write(iocb, io->iov, io->nr_segs, io->iov_offset);
+	ret = cdev_aio_write(iocb, io->iov, io->nr_segs, pos);
 #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	ret = cdev_aio_write(iocb, iter_iov(io), io->nr_segs, pos);
+#else
+	ret = cdev_aio_write(iocb, io->iov, io->nr_segs, pos);
+#endif
+	return ret;
 }
 
 static ssize_t cdev_read_iter(struct kiocb *iocb, struct iov_iter *io)
 {
+	loff_t pos = iocb->ki_pos;
+	ssize_t ret;
 #if defined(RHEL_RELEASE_CODE)
-        #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
-            return cdev_aio_read(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
-        #else
-            return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
-        #endif
-#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
-        return cdev_aio_read(iocb, iter_iov(io), io->nr_segs, io->iov_offset);
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4))
+	ret = cdev_aio_read(iocb, iter_iov(io), io->nr_segs, pos);
 #else
-        return cdev_aio_read(iocb, io->iov, io->nr_segs, io->iov_offset);
+	ret = cdev_aio_read(iocb, io->iov, io->nr_segs, pos);
 #endif
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
+	ret = cdev_aio_read(iocb, iter_iov(io), io->nr_segs, pos);
+#else
+	ret = cdev_aio_read(iocb, io->iov, io->nr_segs, pos);
+#endif
+	return ret;
 }
 #endif
 


### PR DESCRIPTION
#### Summary
This PR fixes a bug in the XDMA character device driver where asynchronous I/O requests (via io_uring) would target the wrong FPGA AXI address. The driver was incorrectly using io->iov_offset instead of iocb->ki_pos as the destination/source address for the DMA transfer.

#### Problem Description
When testing the XDMA-based FPGA functionality using io_uring, my test script included the following three steps:

1. Send data to device address 0x0

2. Send data to device address 0xc0000000

3. Read data from device address 0xd0000000 to the host

However, it was found that the last step could not obtain the correct result. In contrast, using the dma_from_dev and dma_to_dev programs could obtain the correct result.

After enabling debug printing in the XDMA driver, it was found that when using io_uring, the xdma_xfer_submit_nowait function did not print the correct pos (ep_addr) in the debug information.

The log information is shown in the figure below:

<img width="2063" height="1111" alt="ScreenShot_2026-04-15_152241_808" src="https://github.com/user-attachments/assets/acf3a707-0573-453d-a567-318d76479aa4" />

Then, it was found that in the current implementation of cdev_read_iter and cdev_write_iter in cdev_sgdma.c, the driver passes io->iov_offset to the underlying cdev_aio_read/write functions.
However, in the Linux kernel's iov_iter structure:
io->iov_offset represents the consumed bytes within the user-space buffer (usually 0 at the start of a transfer).
iocb->ki_pos represents the actual file/device offset (the target FPGA AXI address).

As a result, any io_uring transfer would mistakenly target AXI address 0.

#### Changes
Modified cdev_read_iter and cdev_write_iter to correctly extract the target AXI address from iocb->ki_pos.
Ensured the correct offset is passed to cdev_aio_read and cdev_aio_write.

#### Testing Performed
Environment: Linux s3950x 5.15.0-174-generic #184-Ubuntu SMP Fri Mar 13 18:41:50 UTC 2026 x86_64 x86_64 x86_64 GNU/Linux
OS: Ubuntu 22.04.5 LTS
Tool: Custom io_uring test application.