### PR TITLE
The Makefile flag EXTRA_CFLAGS was removed

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/Makefile
+++ b/QDMA/linux-kernel/driver/libqdma/Makefile
@@ -35,13 +35,17 @@ include $(srcdir)/../make_rules/common_flags.mk
 $(info srcdir = $(srcdir).)
 $(info KSRC = $(KSRC).)
 
-EXTRA_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
-EXTRA_CFLAGS += $(FLAGS) $(CPPFLAGS)
-EXTRA_CFLAGS += -I$(srcdir)/../include
-EXTRA_CFLAGS += -I$(KSRC)/../include
-EXTRA_CFLAGS += -I.
+E_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
+E_CFLAGS += $(FLAGS) $(CPPFLAGS)
+E_CFLAGS += -I$(srcdir)/../include
+E_CFLAGS += -I$(KSRC)/../include
+E_CFLAGS += -I.
 
-#EXTRA_CFLAGS += -DDEBUG
+#E_CFLAGS += -DDEBUG
+# for backwards compatiblity
+EXTRA_CFLAGS += $(E_CFLAGS)
+ccflags-y += $(E_CFLAGES)
+
 
 ifneq ($(modulesymfile),)
   override symverfile = symverfile="$(topdir)/$(modulesymfile) \

--- a/QDMA/linux-kernel/driver/src/Makefile
+++ b/QDMA/linux-kernel/driver/src/Makefile
@@ -44,15 +44,19 @@ $(info ARCH = $(ARCH).)
 
 MOD_NAME := qdma$(PFVF_TYPE)
 
-EXTRA_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
-EXTRA_CFLAGS += $(FLAGS) $(CPPFLAGS) $(EXTRA_FLAGS)
-EXTRA_CFLAGS += -I$(srcdir)/../include
-EXTRA_CFLAGS += -I$(KSRC)/../include
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_soft_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_soft_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_cpm5_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_cpm4_access
-EXTRA_CFLAGS += -I.
+E_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
+E_CFLAGS += $(FLAGS) $(CPPFLAGS) $(EXTRA_FLAGS)
+E_CFLAGS += -I$(srcdir)/../include
+E_CFLAGS += -I$(KSRC)/../include
+E_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_soft_access
+E_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_soft_access
+E_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_cpm5_access
+E_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_cpm4_access
+E_CFLAGS += -I.
+
+# for backwards compatibilty
+EXTRA_CFLAGS += $(E_CFLAGS)
+ccflags-y += $(E_CFLAGS)
 
 # linux >= 3.13 genl_ops become part of the genl_family. And although
 # genl_register_family_with_ops() is still retained until kernel 4.10,

--- a/XDMA/linux-kernel/xdma/Makefile
+++ b/XDMA/linux-kernel/xdma/Makefile
@@ -20,14 +20,18 @@ topdir := $(shell cd $(src)/.. && pwd)
 
 TARGET_MODULE:=xdma
 
-EXTRA_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
+E_CFLAGS := -I$(topdir)/include $(XVC_FLAGS)
 ifeq ($(DEBUG),1)
-	EXTRA_CFLAGS += -D__LIBXDMA_DEBUG__
+	E_CFLAGS += -D__LIBXDMA_DEBUG__
 endif
 ifneq ($(config_bar_num),)
-	EXTRA_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
+	E_CFLAGS += -DXDMA_CONFIG_BAR_NUM=$(config_bar_num)
 endif
-#EXTRA_CFLAGS += -DINTERNAL_TESTING
+#E_CFLAGS += -DINTERNAL_TESTING
+
+# for backwards compatibility
+EXTRA_CFLAGS += $(E_CFLAGS)
+ccflags-y += $(E_CFLAGS)
 
 ifneq ($(KERNELRELEASE),)
 	$(TARGET_MODULE)-objs := libxdma.o xdma_cdev.o cdev_ctrl.o cdev_events.o cdev_sgdma.o cdev_xvc.o cdev_bypass.o xdma_mod.o xdma_thread.o


### PR DESCRIPTION
The latest Ubuntu 24.04 LTS version does not support the EXTRA_CFLAGS anymore. 
Maybe other distributions are affected too.

The flag EXTRA_CFLAGS was already flagged as deprecated for a long time
and ccflags-y is the replacement.

Reference: Documentation/kbuild/makefiles.txt, section 3.7