### PR TITLE
QDMA: libqdma: select timer_container_of() on RHEL backports (9.8+/10.1+)

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/qdma_compat.h
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_compat.h
@@ -2,7 +2,7 @@
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
  * Copyright (c) 2017-2022, Xilinx, Inc. All rights reserved.
- * Copyright (c) 2022-2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2022-2026, Advanced Micro Devices, Inc. All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -103,5 +103,18 @@
 
 #endif /* timer */
 
+/* from_timer() was renamed to timer_container_of() in upstream v6.16
+ * (commit 41cb08555c41), and backported by Red Hat into RHEL 9.8
+ * (RHEL-115039) and RHEL 10.1 (RHEL-114125).
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)
+#define QDMA_HAVE_TIMER_CONTAINER_OF
+#elif defined(RHEL_RELEASE_CODE)
+#if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 8) && \
+	RHEL_RELEASE_CODE <  RHEL_RELEASE_VERSION(10, 0)) || \
+	(RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(10, 1))
+#define QDMA_HAVE_TIMER_CONTAINER_OF
+#endif
+#endif /* from_timer() */
 
 #endif /* #ifndef __QDMA_COMPAT_H */

--- a/QDMA/linux-kernel/driver/libqdma/qdma_mbox.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_mbox.c
@@ -2,7 +2,7 @@
  * This file is part of the Xilinx DMA IP Core driver for Linux
  *
  * Copyright (c) 2017-2022, Xilinx, Inc. All rights reserved.
- * Copyright (c) 2022-2024, Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2022-2026, Advanced Micro Devices, Inc. All rights reserved.
  *
  * This source code is free software; you can redistribute it and/or modify it
  * under the terms and conditions of the GNU General Public License,
@@ -436,7 +436,7 @@ static void mbox_timer_handler(struct timer_list *t)
 static void mbox_timer_handler(unsigned long arg)
 #endif
 {
-#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 16, 0)
+#if defined(QDMA_HAVE_TIMER_CONTAINER_OF) /* linux v6.16+ or RHEL 9.8+/10.1+ */
 	struct qdma_mbox *mbox = timer_container_of(mbox, t, timer);
 #elif KERNEL_VERSION(4, 15, 0) <= LINUX_VERSION_CODE
 	struct qdma_mbox *mbox = from_timer(mbox, t, timer);


### PR DESCRIPTION
## Summary
`from_timer()` was renamed to `timer_container_of()` upstream in Linux v6.16 (commit `41cb08555c41`). The existing guard in `qdma_mbox.c` keyed solely off `LINUX_VERSION_CODE > KERNEL_VERSION(6, 16, 0)`, which misfires on RHEL-family kernels that backported the rename while keeping an older version string, breaking the build on RHEL/AlmaLinux/Rocky 9.8+ and 10.1+.

Fixes #391

## Changes
- Add a `QDMA_HAVE_TIMER_CONTAINER_OF` feature gate in `qdma_compat.h` that is defined when either:
  - `LINUX_VERSION_CODE >= KERNEL_VERSION(6, 16, 0)` (vanilla), or
  - `RHEL_RELEASE_CODE` indicates **9.8–9.x** or **10.1+** (the backported streams: RHEL-115039 for el9, RHEL-114125 for el10).
- The RHEL comparison is nested under `#elif defined(RHEL_RELEASE_CODE)` so that `RHEL_RELEASE_VERSION(...)` is never evaluated on non-RHEL kernels (where it is undefined and would otherwise be a preprocessor error).
- `qdma_mbox.c` now selects the branch via `#if defined(QDMA_HAVE_TIMER_CONTAINER_OF)`.
- Tighten the upstream check from `>` to `>=` so a vanilla 6.16.0 kernel is also matched (the rename is present *in* 6.16).

## Testing
Compile-tested `make driver KDIR=<tree>` against:
- Ubuntu 6.8 kernel (24.04 HWE kernel) and Ubuntu 7.0 kernel (26.04 kernel)
- AlmaLinux 9.8 (`kernel-devel-5.14.0-687.12.1.el9_8`).