### PR TITLE
QDMA: linux-kernel: use ccflags-y instead of EXTRA_CFLAGS (fix build on Linux 6.15+/Ubuntu 26.04)

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/Makefile
+++ b/QDMA/linux-kernel/driver/libqdma/Makefile
@@ -35,13 +35,13 @@ include $(srcdir)/../make_rules/common_flags.mk
 $(info srcdir = $(srcdir).)
 $(info KSRC = $(KSRC).)
 
-EXTRA_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
-EXTRA_CFLAGS += $(FLAGS) $(CPPFLAGS)
-EXTRA_CFLAGS += -I$(srcdir)/../include
-EXTRA_CFLAGS += -I$(KSRC)/../include
-EXTRA_CFLAGS += -I.
+ccflags-y += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror -Wno-error=empty-body
+ccflags-y += $(FLAGS) $(CPPFLAGS)
+ccflags-y += -I$(srcdir)/../include
+ccflags-y += -I$(KSRC)/../include
+ccflags-y += -I.
 
-#EXTRA_CFLAGS += -DDEBUG
+#ccflags-y += -DDEBUG
 
 ifneq ($(modulesymfile),)
   override symverfile = symverfile="$(topdir)/$(modulesymfile) \

--- a/QDMA/linux-kernel/driver/src/Makefile
+++ b/QDMA/linux-kernel/driver/src/Makefile
@@ -44,15 +44,15 @@ $(info ARCH = $(ARCH).)
 
 MOD_NAME := qdma$(PFVF_TYPE)
 
-EXTRA_CFLAGS += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror
-EXTRA_CFLAGS += $(FLAGS) $(CPPFLAGS) $(EXTRA_FLAGS)
-EXTRA_CFLAGS += -I$(srcdir)/../include
-EXTRA_CFLAGS += -I$(KSRC)/../include
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_soft_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_soft_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/eqdma_cpm5_access
-EXTRA_CFLAGS += -I$(srcdir)/../libqdma/qdma_access/qdma_cpm4_access
-EXTRA_CFLAGS += -I.
+ccflags-y += -DLINUX -D__KERNEL__ -DMODULE -O2 -pipe -Wall -Werror -Wno-error=empty-body
+ccflags-y += $(FLAGS) $(CPPFLAGS) $(EXTRA_FLAGS)
+ccflags-y += -I$(srcdir)/../include
+ccflags-y += -I$(KSRC)/../include
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/qdma_soft_access
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/eqdma_soft_access
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/eqdma_cpm5_access
+ccflags-y += -I$(srcdir)/../libqdma/qdma_access/qdma_cpm4_access
+ccflags-y += -I.
 
 # linux >= 3.13 genl_ops become part of the genl_family. And although
 # genl_register_family_with_ops() is still retained until kernel 4.10,
@@ -82,7 +82,7 @@ endif
 
 $(info EXTRA_FLAGS = $(EXTRA_FLAGS).)
 $(info ccflags-y = $(ccflags-y).)
-#EXTRA_CFLAGS += -DDEBUG
+#ccflags-y += -DDEBUG
 
 #For Kernel Images > 4.9.199 with CONFIG_STACK_VALIDATION=y and GCC version > 8 compiler throws spurious warnings
 #related to sibling calls and frame pointer save/setup. To supress these warnings


### PR DESCRIPTION
### Summary

Fixes the QDMA Linux kernel driver build on Linux ≥ 6.15, including the Ubuntu 26.04 LTS kernel (7.0). kbuild removed EXTRA_CFLAGS support in 6.15, so the driver's include paths were silently dropped, causing:

```
In file included from nl.c:27:
libqdma/libqdma_export.h:41:10: fatal error: qdma_access_export.h: No such file or directory
   41 | #include "qdma_access_export.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Fixes #393 

### Changes

- `QDMA/linux-kernel/driver/src/Makefile`: EXTRA_CFLAGS -> ccflags-y
- `QDMA/linux-kernel/driver/libqdma/Makefile`: `EXTRA_CFLAGS` -> ccflags-y
- Added `-Wno-error=empty-body` so `-Wall -Werror` no longer fails on the empty if body in libqdma/thread.c with newer GCC.

### Why ccflags-y

EXTRA_CFLAGS was deprecated in 2007 and removed in Linux 6.15 (torvalds/linux@e966ad0edd00). ccflags-y is the supported replacement and has existed since kernel 2.6.24, so this stays compatible with older kernels.

### Note for reviewers

The empty-body case is handled by suppressing `-Werror=empty-body`. If you'd prefer, the underlying `if (detail) ;` in libqdma/thread.c can instead be cleaned up directly. Happy to adjust.