### PR TITLE
QDMA: release cdev region on device cleanup to stop major-number leak

### DIFF
--- a/QDMA/linux-kernel/driver/src/cdev.c
+++ b/QDMA/linux-kernel/driver/src/cdev.c
@@ -55,6 +55,7 @@ struct xlnx_phy_dev {
 	unsigned int device_bus_domain; /**< PCIe bus domain per board */
 #endif
 	unsigned int dma_device_index;
+	int refcnt;	/**< number of PFs sharing this board's major */
 };
 
 static LIST_HEAD(xlnx_phy_dev_list);
@@ -745,8 +746,29 @@ err_out:
  */
 void qdma_cdev_device_cleanup(struct qdma_cdev_cb *xcb)
 {
+	struct xlnx_phy_dev *phy_dev, *tmp;
+
 	if (!xcb->cdev_major)
 		return;
+
+	/* Release this board's char-device region once the last PF sharing
+	 * the major is gone. Without this the region leaks on every device
+	 * remove (e.g. PCIe remove/rescan) and the dynamic major pool fills
+	 * up, eventually failing probe with -EBUSY in qdma_cdev_device_init.
+	 */
+	mutex_lock(&xlnx_phy_dev_mutex);
+	list_for_each_entry_safe(phy_dev, tmp, &xlnx_phy_dev_list, list_head) {
+		if (phy_dev->major != xcb->cdev_major)
+			continue;
+		if (--phy_dev->refcnt == 0) {
+			unregister_chrdev_region(MKDEV(phy_dev->major, 0),
+					QDMA_MINOR_MAX);
+			list_del(&phy_dev->list_head);
+			kfree(phy_dev);
+		}
+		break;
+	}
+	mutex_unlock(&xlnx_phy_dev_mutex);
 
 	xcb->cdev_major = 0;
 }
@@ -780,6 +802,7 @@ int qdma_cdev_device_init(struct qdma_cdev_cb *xcb)
 #endif
 			phy_dev->dma_device_index == xdev->dma_device_index) {
 			xcb->cdev_major = phy_dev->major;
+			phy_dev->refcnt++;
 			mutex_unlock(&xlnx_phy_dev_mutex);
 			return 0;
 		}
@@ -807,6 +830,7 @@ int qdma_cdev_device_init(struct qdma_cdev_cb *xcb)
 	new_phy_dev->device_bus_domain = xcb->xpdev->pdev->bus->domain_nr;
 #endif
 	new_phy_dev->dma_device_index = xdev->dma_device_index;
+	new_phy_dev->refcnt = 1;
 	xlnx_phy_dev_list_add(new_phy_dev);
 
 	return 0;


### PR DESCRIPTION
## Problem

`qdma_cdev_device_cleanup()` clears `xcb->cdev_major` but never calls
`unregister_chrdev_region()`. The 4096-minor character-device region that each
board allocates in `qdma_cdev_device_init()` is therefore leaked on every device
remove (for example a PCIe remove/rescan). The region is only ever reclaimed by
the module-wide `qdma_cdev_cleanup()` at module unload.

As a result, repeated remove/rescan cycles steadily consume the kernel's pool of
*dynamic* character-device major numbers. Once the pool is exhausted,
`alloc_chrdev_region()` returns `-EBUSY` and probe fails:

CHRDEV "qdma-pf" dynamic allocation region is full
qdma_pf:qdma_cdev_device_init: unable to allocate cdev region -16.
qdma-pf: probe of 0000:XX:00.1 failed with error -16

This was observed on with V80 FPGAs (QDMA PF on `XX:00.1`): after a number of
remove/rescan cycles, `/proc/devices` showed ~126 `qdma-pf` majors held, filling
the entire `384–511` dynamic range, and all subsequent probes failed with `-16`.
The only stock recovery is a full `rmmod` / `modprobe`, which is undesirable in
production.

## Fix

Reference-count each board's major number. Multiple PFs on the same bus already
share one major via the dedup path in `qdma_cdev_device_init()`, so the count is
incremented there and initialised to 1 for a freshly allocated board.
`qdma_cdev_device_cleanup()` now decrements the count and, when the last PF on
the board goes away, releases the region with `unregister_chrdev_region()` +
`list_del()` + `kfree()`. The module-wide `qdma_cdev_cleanup()` remains as a
safety net.

With this change, remove/rescan no longer leaks majors and the `-16` exhaustion
no longer occurs.

## Testing

Tested on a host with six V80s (QDMA 2024.1.0, kernel
5.15.0-179-generic), counting `grep -c qdma-pf /proc/devices` across PCIe
remove/rescan cycles on one (idle) card:

- **Before (stock module):** baseline 6 majors → 7 → 8, climbing by one per
  remove/rescan cycle while the number of bound PFs stayed at 6. In production
  this had accumulated ~126 leaked majors, filling the `384–511` dynamic range
  and failing all subsequent probes with `-16`.
- **After (this patch):** baseline 6 majors, holding steady at 6 across four
  remove/rescan cycles, with all 6 PFs re-binding each time. Normal
  load/unload/queue setup unaffected. Builds clean under `-Werror`.