### PR TITLE
XDMA Driver General Bugfixes

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_bypass.c
+++ b/XDMA/linux-kernel/xdma/cdev_bypass.c
@@ -18,20 +18,27 @@
  */
 #define pr_fmt(fmt)	KBUILD_MODNAME ":%s: " fmt, __func__
 
+#include <linux/slab.h>
+#include <linux/vmalloc.h>
 #include "libxdma_api.h"
 #include "xdma_cdev.h"
 
 #define write_register(v, mem, off) iowrite32(v, mem)
 
-static int copy_desc_data(struct xdma_transfer *transfer, char __user *buf,
+/*
+ * Copy a transfer's descriptors into the kernel staging buffer kbuf. Runs under
+ * engine->lock, so it must not touch userspace (copy_to_user can fault and
+ * sleep, which is illegal while holding a spinlock). The caller copies kbuf out
+ * to userspace after dropping the lock.
+ */
+static int copy_desc_data(struct xdma_transfer *transfer, char *kbuf,
 		size_t *buf_offset, size_t buf_size)
 {
 	int i;
-	int copy_err;
 	int rc = 0;
 
-	if (!buf) {
-		pr_err("Invalid user buffer\n");
+	if (!kbuf) {
+		pr_err("Invalid kernel buffer\n");
 		return -EINVAL;
 	}
 
@@ -40,20 +47,12 @@ static int copy_desc_data(struct xdma_transfer *transfer, char __user *buf,
 		return -EINVAL;
 	}
 
-	/* Fill user buffer with descriptor data */
+	/* Stage descriptor data into the kernel buffer */
 	for (i = 0; i < transfer->desc_num; i++) {
 		if (*buf_offset + sizeof(struct xdma_desc) <= buf_size) {
-			copy_err = copy_to_user(&buf[*buf_offset],
-				transfer->desc_virt + i,
+			memcpy(kbuf + *buf_offset, transfer->desc_virt + i,
 				sizeof(struct xdma_desc));
-
-			if (copy_err) {
-				dbg_sg("Copy to user buffer failed\n");
-				*buf_offset = buf_size;
-				rc = -EINVAL;
-			} else {
-				*buf_offset += sizeof(struct xdma_desc);
-			}
+			*buf_offset += sizeof(struct xdma_desc);
 		} else {
 			rc = -ENOMEM;
 		}
@@ -71,6 +70,7 @@ static ssize_t char_bypass_read(struct file *file, char __user *buf,
 	struct xdma_transfer *transfer;
 	struct list_head *idx;
 	size_t buf_offset = 0;
+	char *kbuf;
 	int rc = 0;
 
 	rc = xcdev_check(__func__, xcdev, 1);
@@ -96,17 +96,32 @@ static ssize_t char_bypass_read(struct file *file, char __user *buf,
 		return -ENODEV;
 	}
 
+	/* Stage descriptors into a kernel buffer under the lock, then copy out
+	 * to userspace after unlocking: copy_to_user may fault/sleep and must
+	 * not run while holding engine->lock (a spinlock).
+	 */
+	kbuf = kvzalloc(count, GFP_KERNEL);
+	if (!kbuf)
+		return -ENOMEM;
+
 	spin_lock(&engine->lock);
 
 	if (!list_empty(&engine->transfer_list)) {
 		list_for_each(idx, &engine->transfer_list) {
 			transfer = list_entry(idx, struct xdma_transfer, entry);
 
-			rc = copy_desc_data(transfer, buf, &buf_offset, count);
+			rc = copy_desc_data(transfer, kbuf, &buf_offset, count);
 		}
 	}
 
 	spin_unlock(&engine->lock);
+
+	if (rc == 0 && buf_offset) {
+		if (copy_to_user(buf, kbuf, buf_offset))
+			rc = -EFAULT;
+	}
+
+	kvfree(kbuf);
 
 	if (rc < 0)
 		return rc;
@@ -121,11 +136,10 @@ static ssize_t char_bypass_write(struct file *file, const char __user *buf,
 	struct xdma_engine *engine;
 	struct xdma_cdev *xcdev = (struct xdma_cdev *)file->private_data;
 
-	u32 desc_data;
 	void __iomem *bypass_addr;
 	size_t buf_offset = 0;
+	u32 *kbuf;
 	int rc = 0;
-	int copy_err;
 
 	rc = xcdev_check(__func__, xcdev, 1);
 	if (rc < 0)
@@ -150,30 +164,38 @@ static ssize_t char_bypass_write(struct file *file, const char __user *buf,
 
 	dbg_sg("In %s()\n", __func__);
 
+	/* Copy the whole user buffer in before taking the lock: copy_from_user
+	 * may fault/sleep and must not run while holding engine->lock (a
+	 * spinlock). The MMIO writes below then run lock-held against kbuf.
+	 */
+	kbuf = kvmalloc(count, GFP_KERNEL);
+	if (!kbuf)
+		return -ENOMEM;
+	if (copy_from_user(kbuf, buf, count)) {
+		dbg_sg("Error reading data from userspace buffer\n");
+		kvfree(kbuf);
+		return -EFAULT;
+	}
+
 	spin_lock(&engine->lock);
 
-	/* Write descriptor data to the bypass BAR */
-	bypass_addr = xdev->bar[xdev->bypass_bar_idx];
-	bypass_addr = (void __iomem *)(
-			(u32 __iomem *)bypass_addr + engine->bypass_offset
-			);
+	/* Write descriptor data to the bypass BAR. engine->bypass_offset is a
+	 * BYTE offset into the bypass BAR (engines_num * BYPASS_MODE_SPACING),
+	 * so add it to the void __iomem * base directly. The previous code cast
+	 * the base to (u32 __iomem *) before adding, which scaled the offset by
+	 * 4 and sent every engine past channel 0 to bar + bypass_offset*4. The
+	 * per-DWORD streaming to this fixed bypass address is unchanged. */
+	bypass_addr = xdev->bar[xdev->bypass_bar_idx] + engine->bypass_offset;
 	while (buf_offset < count) {
-		copy_err = copy_from_user(&desc_data, &buf[buf_offset],
-			sizeof(u32));
-		if (!copy_err) {
-			write_register(desc_data, bypass_addr,
-					bypass_addr - engine->bypass_offset);
-			buf_offset += sizeof(u32);
-			rc = buf_offset;
-		} else {
-			dbg_sg("Error reading data from userspace buffer\n");
-			rc = -EINVAL;
-			break;
-		}
+		write_register(kbuf[buf_offset / sizeof(u32)], bypass_addr,
+				engine->bypass_offset);
+		buf_offset += sizeof(u32);
+		rc = buf_offset;
 	}
 
 	spin_unlock(&engine->lock);
 
+	kvfree(kbuf);
 
 	return rc;
 }

--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -32,6 +32,26 @@
 #endif
 
 /*
+ * Return 0 if a [pos, pos + count) access falls within the mapped BAR window,
+ * non-zero otherwise. map_single_bar() caps the mapping at INT_MAX bytes, so
+ * the usable window is min(pci_resource_len, INT_MAX). pos is a user-controlled
+ * loff_t; this guards the register read/write paths against out-of-bounds MMIO.
+ */
+static inline int xdma_cdev_bar_access_ok(struct xdma_dev *xdev, int bar,
+					loff_t pos, size_t count)
+{
+	resource_size_t bar_len = pci_resource_len(xdev->pdev, bar);
+
+	if (bar_len > INT_MAX)
+		bar_len = INT_MAX;
+
+	if (pos < 0 || (u64)pos + count > (u64)bar_len)
+		return -EINVAL;
+
+	return 0;
+}
+
+/*
  * character device file operations for control bus (through control bridge)
  */
 static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
@@ -48,9 +68,17 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 		return rv;
 	xdev = xcdev->xdev;
 
+	/* this is a 32-bit register interface: require exactly a 4-byte access
+	 * so we never touch more of the user buffer than the caller asked for
+	 * (the sibling char_events_read enforces the same). */
+	if (count != 4)
+		return -EPROTO;
 	/* only 32-bit aligned and 32-bit multiples */
 	if (*pos & 3)
 		return -EPROTO;
+	/* bound the user-controlled offset to the mapped BAR window */
+	if (xdma_cdev_bar_access_ok(xdev, xcdev->bar, *pos, 4))
+		return -EINVAL;
 	/* first address is BAR base plus file position offset */
 	reg = xdev->bar[xcdev->bar] + *pos;
 	//w = read_register(reg);
@@ -59,7 +87,7 @@ static ssize_t char_ctrl_read(struct file *fp, char __user *buf, size_t count,
 			__func__, reg, (long)count, (int)*pos, w);
 	rv = copy_to_user(buf, &w, 4);
 	if (rv)
-		dbg_sg("Copy to userspace failed but continuing\n");
+		return -EFAULT;
 
 	*pos += 4;
 	return 4;
@@ -79,15 +107,28 @@ static ssize_t char_ctrl_write(struct file *file, const char __user *buf,
 		return rv;
 	xdev = xcdev->xdev;
 
+	/* 32-bit register interface: require exactly a 4-byte access so we
+	 * never read past the caller's buffer. */
+	if (count != 4)
+		return -EPROTO;
+
 	/* only 32-bit aligned and 32-bit multiples */
 	if (*pos & 3)
 		return -EPROTO;
 
+	/* bound the user-controlled offset to the mapped BAR window */
+	if (xdma_cdev_bar_access_ok(xdev, xcdev->bar, *pos, 4))
+		return -EINVAL;
+
 	/* first address is BAR base plus file position offset */
 	reg = xdev->bar[xcdev->bar] + *pos;
 	rv = copy_from_user(&w, buf, 4);
-	if (rv)
-		pr_info("copy from user failed %d/4, but continuing.\n", rv);
+	if (rv) {
+		/* w would be uninitialized/partial; do NOT push stack garbage to
+		 * the hardware register. Fail the write instead of "continuing". */
+		pr_info("copy from user failed %d/4.\n", rv);
+		return -EFAULT;
+	}
 
 	dbg_sg("%s(0x%08x @%p, count=%ld, pos=%d)\n",
 			__func__, w, reg, (long)count, (int)*pos);
@@ -206,12 +247,28 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	xdev = xcdev->xdev;
 
 	off = vma->vm_pgoff << PAGE_SHIFT;
+
+	/*
+	 * Validate the user-supplied offset against the BAR length before
+	 * computing psize. The original psize = end - start + 1 - off
+	 * subtraction underflows to a huge value when off exceeds the BAR
+	 * length, defeating the vsize > psize check below and letting userspace
+	 * map physical memory beyond the BAR. Reject off past the BAR here.
+	 */
+	{
+		unsigned long blen = pci_resource_len(xdev->pdev, xcdev->bar);
+
+		if (off >= blen) {
+			dbg_sg("mmap offset 0x%lx beyond BAR len 0x%lx\n", off,
+				blen);
+			return -EINVAL;
+		}
+		psize = blen - off;
+	}
+
 	/* BAR physical address */
 	phys = pci_resource_start(xdev->pdev, xcdev->bar) + off;
 	vsize = vma->vm_end - vma->vm_start;
-	/* complete resource */
-	psize = pci_resource_end(xdev->pdev, xcdev->bar) -
-		pci_resource_start(xdev->pdev, xcdev->bar) + 1 - off;
 
 	dbg_sg("mmap(): xcdev = 0x%08lx\n", (unsigned long)xcdev);
 	dbg_sg("mmap(): cdev->bar = %d\n", xcdev->bar);

--- a/XDMA/linux-kernel/xdma/cdev_sgdma.c
+++ b/XDMA/linux-kernel/xdma/cdev_sgdma.c
@@ -45,6 +45,13 @@ unsigned int c2h_timeout = 10;
 module_param(c2h_timeout, uint, 0644);
 MODULE_PARM_DESC(c2h_timeout, "C2H sgdma timeout in seconds, default is 10 sec.");
 
+/* Upper bound on iovec segments accepted by the async read/write paths. The
+ * VFS already caps iov_iter at UIO_MAXIOV (1024); cap here too so the cb-array
+ * allocation can never be driven to overflow or an unreasonable size by a
+ * crafted io_submit.
+ */
+#define XDMA_AIO_MAX_SEGS	1024
+
 extern struct kmem_cache *cdev_cache;
 static void char_sgdma_unmap_user_buf(struct xdma_io_cb *cb, bool write);
 
@@ -124,17 +131,29 @@ static void async_io_handler(unsigned long  cb_hndl, int err)
 #endif
 skip_tran:
 		spin_unlock(&caio->lock);
+		/*
+		 * cb points into the caio->cb[] array (each transfer was
+		 * submitted with &caio->cb[i] as its handle), so it must not be
+		 * freed individually. Free the whole array once, here on the
+		 * final completion, together with caio.
+		 */
+		kfree(caio->cb);
 		kmem_cache_free(cdev_cache, caio);
-		kfree(cb);
 		return;
-	} 
+	}
 	spin_unlock(&caio->lock);
 	return;
 
 skip_dev_lock:
+	/*
+	 * This path is taken when the caio lock could not be acquired (a cancel
+	 * is in progress). res/res2 are only assigned on the final-completion
+	 * path above, so report a definite error code instead of reading those
+	 * uninitialized stack values (the older variants already pass -EBUSY).
+	 */
 #if defined(RHEL_RELEASE_CODE)
     #if (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 0))
-        caio->iocb->ki_complete(caio->iocb, caio->err_cnt ? res2 : res);
+        caio->iocb->ki_complete(caio->iocb, -EBUSY);
     #elif LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
         caio->iocb->ki_complete(caio->iocb, -EBUSY);
     #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
@@ -149,6 +168,7 @@ skip_dev_lock:
 #else
 	aio_complete(caio->iocb, numbytes, -EBUSY);
 #endif
+	kfree(caio->cb);
 	kmem_cache_free(cdev_cache, caio);
 }
 
@@ -362,7 +382,14 @@ static int char_sgdma_map_user_buf_to_sgl(struct xdma_io_cb *cb, bool write)
 
 	if (len) {
 		pr_err("Invalid user buffer length. Cannot map to sgl\n");
-		return -EINVAL;
+		/* pages are already pinned and the sgl built; record pages_nr
+		 * and go through err_out so they are unpinned/freed. Returning
+		 * directly here left cb->pages_nr == 0, making the caller's
+		 * unmap a no-op and leaking the pinned pages and sg table.
+		 */
+		cb->pages_nr = pages_nr;
+		rv = -EINVAL;
+		goto err_out;
 	}
 	cb->pages_nr = pages_nr;
 	return 0;
@@ -463,10 +490,24 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		return -EINVAL;
 	}
 
+	/* count is the user-controlled iovec segment count; reject 0 and a
+	 * value so large the cb-array allocation could overflow or exhaust
+	 * memory.
+	 */
+	if (!count || count > XDMA_AIO_MAX_SEGS)
+		return -EINVAL;
+
 	caio = kmem_cache_alloc(cdev_cache, GFP_KERNEL);
+	if (!caio)
+		return -ENOMEM;
 	memset(caio, 0, sizeof(struct cdev_async_io));
 
-	caio->cb = kzalloc(count * (sizeof(struct xdma_io_cb)), GFP_KERNEL);
+	/* kcalloc is overflow-checked, unlike the open-coded count * sizeof */
+	caio->cb = kcalloc(count, sizeof(struct xdma_io_cb), GFP_KERNEL);
+	if (!caio->cb) {
+		kmem_cache_free(cdev_cache, caio);
+		return -ENOMEM;
+	}
 
 	spin_lock_init(&caio->lock);
 	iocb->private = caio;
@@ -475,8 +516,15 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 	caio->cancel = false;
 	caio->req_cnt = count;
 
+	/* Pass 1: validate and pin/map every segment BEFORE submitting any.
+	 * The original code mapped and submitted in the same loop, so a failure
+	 * on a later segment returned with earlier transfers already in flight
+	 * (referencing caio) - leaking caio/cb/sg-tables/pages, hanging the iocb
+	 * (req_cnt never reached), and freeing caio out from under in-flight
+	 * completion callbacks. Doing all validation/mapping first means any
+	 * failure here is fully recoverable synchronously: nothing is in flight.
+	 */
 	for (i = 0; i < count; i++) {
-
 		memset(&(caio->cb[i]), 0, sizeof(struct xdma_io_cb));
 
 		caio->cb[i].buf = io[i].iov_base;
@@ -485,28 +533,40 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		caio->cb[i].write = true;
 		caio->cb[i].private = caio;
 		caio->cb[i].io_done = async_io_handler;
+
 		rv = check_transfer_align(engine, caio->cb[i].buf,
 					caio->cb[i].len, pos, 1);
 		if (rv) {
 			pr_info("Invalid transfer alignment detected\n");
-			kmem_cache_free(cdev_cache, caio);
-			return rv;
+			goto err_unmap;
 		}
 
 		rv = char_sgdma_map_user_buf_to_sgl(&caio->cb[i], true);
 		if (rv < 0)
-			return rv;
+			goto err_unmap;
+	}
 
-		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
+	/* Pass 2: all segments mapped; submit them. */
+	for (i = 0; i < count; i++) {
+		xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
 					0, h2c_timeout * 1000);
 	}
 
-	if (engine->cmplthp)
-		xdma_kthread_wakeup(engine->cmplthp);
+	xdma_engine_kthread_wakeup(engine);
 
 	return -EIOCBQUEUED;
+
+err_unmap:
+	/* unmap/unpin the segments mapped so far (0..i); cb[i] may be partially
+	 * mapped - char_sgdma_unmap_user_buf tolerates that.
+	 */
+	while (i-- > 0)
+		char_sgdma_unmap_user_buf(&caio->cb[i], true);
+	kfree(caio->cb);
+	kmem_cache_free(cdev_cache, caio);
+	return rv;
 }
 
 static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
@@ -536,10 +596,24 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 		return -EINVAL;
 	}
 
+	/* count is the user-controlled iovec segment count; reject 0 and a
+	 * value so large the cb-array allocation could overflow or exhaust
+	 * memory.
+	 */
+	if (!count || count > XDMA_AIO_MAX_SEGS)
+		return -EINVAL;
+
 	caio = kmem_cache_alloc(cdev_cache, GFP_KERNEL);
+	if (!caio)
+		return -ENOMEM;
 	memset(caio, 0, sizeof(struct cdev_async_io));
 
-	caio->cb = kzalloc(count * (sizeof(struct xdma_io_cb)), GFP_KERNEL);
+	/* kcalloc is overflow-checked, unlike the open-coded count * sizeof */
+	caio->cb = kcalloc(count, sizeof(struct xdma_io_cb), GFP_KERNEL);
+	if (!caio->cb) {
+		kmem_cache_free(cdev_cache, caio);
+		return -ENOMEM;
+	}
 
 	spin_lock_init(&caio->lock);
 	iocb->private = caio;
@@ -548,8 +622,10 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 	caio->cancel = false;
 	caio->req_cnt = count;
 
+	/* Pass 1: validate and pin/map every segment before submitting any
+	 * (see cdev_aio_write for the rationale).
+	 */
 	for (i = 0; i < count; i++) {
-
 		memset(&(caio->cb[i]), 0, sizeof(struct xdma_io_cb));
 
 		caio->cb[i].buf = io[i].iov_base;
@@ -563,24 +639,32 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 					caio->cb[i].len, pos, 1);
 		if (rv) {
 			pr_info("Invalid transfer alignment detected\n");
-			kmem_cache_free(cdev_cache, caio);
-			return rv;
+			goto err_unmap;
 		}
 
 		rv = char_sgdma_map_user_buf_to_sgl(&caio->cb[i], false);
 		if (rv < 0)
-			return rv;
+			goto err_unmap;
+	}
 
-		rv = xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
+	/* Pass 2: all segments mapped; submit them. */
+	for (i = 0; i < count; i++) {
+		xdma_xfer_submit_nowait((void *)&caio->cb[i], xdev,
 					engine->channel, caio->cb[i].write,
 					caio->cb[i].ep_addr, &caio->cb[i].sgt,
 					0, c2h_timeout * 1000);
 	}
 
-	if (engine->cmplthp)
-		xdma_kthread_wakeup(engine->cmplthp);
+	xdma_engine_kthread_wakeup(engine);
 
 	return -EIOCBQUEUED;
+
+err_unmap:
+	while (i-- > 0)
+		char_sgdma_unmap_user_buf(&caio->cb[i], false);
+	kfree(caio->cb);
+	kmem_cache_free(cdev_cache, caio);
+	return rv;
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 16, 0)
@@ -648,13 +732,27 @@ static int ioctl_do_perf_start(struct xdma_engine *engine, unsigned long arg)
 		(struct xdma_performance_ioctl __user *)arg,
 		sizeof(struct xdma_performance_ioctl));
 
-	if (rv < 0) {
+	/* copy_from_user returns the number of bytes NOT copied (0 on success),
+	 * never a negative value, so the old "rv < 0" test never fired.
+	 *
+	 * On every error after the kzalloc above, free engine->xdma_perf and
+	 * clear the pointer. Otherwise the buffer leaks and, worse, the
+	 * "already running" guard at the top of this function sees a non-NULL
+	 * xdma_perf and wedges the engine's perf interface at -EBUSY forever
+	 * (it is only freed by a successful PERF_STOP, which is unreachable
+	 * once start failed).
+	 */
+	if (rv) {
 		dbg_perf("Failed to copy from user space 0x%lx\n", arg);
-		return -EINVAL;
+		kfree(engine->xdma_perf);
+		engine->xdma_perf = NULL;
+		return -EFAULT;
 	}
 	if (engine->xdma_perf->version != IOCTL_XDMA_PERF_V1) {
 		dbg_perf("Unsupported IOCTL version %d\n",
 			engine->xdma_perf->version);
+		kfree(engine->xdma_perf);
+		engine->xdma_perf = NULL;
 		return -EINVAL;
 	}
 
@@ -667,14 +765,18 @@ static int ioctl_do_perf_start(struct xdma_engine *engine, unsigned long arg)
 	init_waitqueue_head(&engine->xdma_perf_wq);
 #endif
 	rv = xdma_performance_submit(xdev, engine);
-	if (rv < 0)
+	if (rv < 0) {
 		pr_err("Failed to submit dma performance\n");
+		kfree(engine->xdma_perf);
+		engine->xdma_perf = NULL;
+	}
 	return rv;
 }
 
 static int ioctl_do_perf_stop(struct xdma_engine *engine, unsigned long arg)
 {
 	struct xdma_transfer *transfer = NULL;
+	unsigned long flags;
 	int rv;
 
 	if (!engine) {
@@ -690,13 +792,34 @@ static int ioctl_do_perf_stop(struct xdma_engine *engine, unsigned long arg)
 		return -EINVAL;
 	}
 
-	/* stop measurement */
+	/*
+	 * stop measurement. engine_cyclic_stop() reads engine->transfer_list
+	 * and calls list_del() on the head transfer; it documents that
+	 * engine->lock must be held. The caller (here) is responsible for the
+	 * lock - engine_service_work() walks the same list under engine->lock,
+	 * so without it the two list_del paths can race (list corruption / UAF).
+	 */
+	spin_lock_irqsave(&engine->lock, flags);
 	transfer = engine_cyclic_stop(engine);
+	spin_unlock_irqrestore(&engine->lock, flags);
 	if (!transfer) {
 		pr_err("Failed to stop cyclic transfer\n");
 		return -EINVAL;
 	}
 	dbg_perf("Waiting for measurement to stop\n");
+
+	/*
+	 * engine_cyclic_stop() halted the engine and unlinked the cyclic
+	 * transfer, but a previously scheduled engine_service_work() may still
+	 * be queued or running. That work item reads engine->xdma_perf (in
+	 * engine_service_perf()) under engine->lock. Drain it here - outside
+	 * the spinlock, since cancel_work_sync() may sleep - before we free
+	 * engine->xdma_perf / the transfer below, otherwise the service path
+	 * can dereference freed memory. xdma_engine_stop() inside
+	 * engine_cyclic_stop() already disabled the engine interrupt, so no new
+	 * work will be scheduled.
+	 */
+	cancel_work_sync(&engine->work);
 
 	get_perf_stats(engine);
 
@@ -704,7 +827,13 @@ static int ioctl_do_perf_stop(struct xdma_engine *engine, unsigned long arg)
 			sizeof(struct xdma_performance_ioctl));
 	if (rv) {
 		dbg_perf("Error copying result to user\n");
-		return rv;
+		/*
+		 * engine_cyclic_stop() already unlinked this transfer from the
+		 * engine list and handed us its sole reference, so it must be
+		 * freed here too or it leaks on the copy_to_user failure path.
+		 */
+		kfree(transfer);
+		return -EFAULT;
 	}
 
 	kfree(transfer);
@@ -787,10 +916,11 @@ static int ioctl_do_aperture_dma(struct xdma_engine *engine, unsigned long arg,
 
 	rv = copy_from_user(&io, (struct xdma_aperture_ioctl __user *)arg,
 				sizeof(struct xdma_aperture_ioctl));
-	if (rv < 0) {
+	/* copy_from_user returns bytes-not-copied (0 on success), never < 0 */
+	if (rv) {
 		dbg_tfr("%s failed to copy from user space 0x%lx\n",
 			engine->name, arg);
-		return -EINVAL;
+		return -EFAULT;
 	}
 
 	dbg_tfr("%s, W %d, buf 0x%lx,%lu, ep %llu, aperture %u.\n",
@@ -832,10 +962,14 @@ static int ioctl_do_aperture_dma(struct xdma_engine *engine, unsigned long arg,
 
 	rv = copy_to_user((struct xdma_aperture_ioctl __user *)arg, &io,
 				sizeof(struct xdma_aperture_ioctl));
-	if (rv < 0) {
+	/* copy_to_user returns bytes-not-copied (0 on success), never < 0, so
+	 * the old "rv < 0" test was dead code and a real copy-back fault was
+	 * reported to userspace as success. Test != 0 and return -EFAULT.
+	 */
+	if (rv) {
 		dbg_tfr("%s failed to copy to user space 0x%lx, %ld\n",
 			engine->name, arg, res);
-		return -EINVAL;
+		return -EFAULT;
 	}
 
 	return io.error;
@@ -902,11 +1036,22 @@ static int char_sgdma_open(struct inode *inode, struct file *file)
 	engine = xcdev->engine;
 
 	if (engine->streaming && engine->dir == DMA_FROM_DEVICE) {
-		if (engine->device_open == 1)
-			return -EBUSY;
-		engine->device_open = 1;
+		unsigned long flags;
 
+		/* Test-and-set the single-open flag atomically under engine->lock.
+		 * The original unlocked check-then-set let two concurrent opens of
+		 * the same ST C2H node both succeed, and device_open is a 1-bit
+		 * bitfield sharing a byte with other engine flags, so a racing RMW
+		 * could also clobber neighbours.
+		 */
+		spin_lock_irqsave(&engine->lock, flags);
+		if (engine->device_open == 1) {
+			spin_unlock_irqrestore(&engine->lock, flags);
+			return -EBUSY;
+		}
+		engine->device_open = 1;
 		engine->eop_flush = (file->f_flags & O_TRUNC) ? 1 : 0;
+		spin_unlock_irqrestore(&engine->lock, flags);
 	}
 
 	return 0;
@@ -924,8 +1069,14 @@ static int char_sgdma_close(struct inode *inode, struct file *file)
 
 	engine = xcdev->engine;
 
-	if (engine->streaming && engine->dir == DMA_FROM_DEVICE)
+	if (engine->streaming && engine->dir == DMA_FROM_DEVICE) {
+		unsigned long flags;
+
+		/* clear the single-open flag under the same lock used to set it */
+		spin_lock_irqsave(&engine->lock, flags);
 		engine->device_open = 0;
+		spin_unlock_irqrestore(&engine->lock, flags);
+	}
 
 	return 0;
 }

--- a/XDMA/linux-kernel/xdma/cdev_xvc.c
+++ b/XDMA/linux-kernel/xdma/cdev_xvc.c
@@ -24,6 +24,15 @@
 
 #define COMPLETION_LOOP_MAX	100
 
+/*
+ * Upper bound on the user-supplied JTAG shift length (in bits). A single XVC
+ * shift transaction is small in practice; this cap keeps the size arithmetic
+ * below from overflowing unsigned int (see xvc_ioctl) while remaining far
+ * larger than any legitimate request. total_bytes maxes at 128 KiB, so the
+ * three sub-buffers fit in a 384 KiB allocation.
+ */
+#define XVC_MAX_BITS		(1 << 20)
+
 #define XVC_BAR_LENGTH_REG	0x0
 #define XVC_BAR_TMS_REG		0x4
 #define XVC_BAR_TDI_REG		0x8
@@ -119,9 +128,13 @@ static long xvc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 
 	rv = copy_from_user((void *)&xvc_obj, (void __user *)arg,
 				sizeof(struct xvc_ioc));
-	/* anything not copied ? */
+	/* anything not copied ? copy_from_user returns bytes-not-copied, a
+	 * positive value; translate to -EFAULT so the ioctl does not return a
+	 * bogus positive count as its result.
+	 */
 	if (rv) {
 		pr_info("copy_from_user xvc_obj failed: %d.\n", rv);
+		rv = -EFAULT;
 		goto cleanup;
 	}
 
@@ -134,9 +147,22 @@ static long xvc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	}
 
 	total_bits = xvc_obj.length;
+
+	/*
+	 * Validate the user-supplied length before any size arithmetic. Without
+	 * this, total_bytes * 3 (an unsigned int multiply) can wrap, yielding a
+	 * tiny allocation that the copy_from_user calls below then overflow, and
+	 * a length of 0 would lead to a zero-sized allocation with a non-empty
+	 * shift loop. Reject 0 and cap to XVC_MAX_BITS.
+	 */
+	if (total_bits == 0 || total_bits > XVC_MAX_BITS) {
+		pr_info("invalid XVC length %u bits.\n", total_bits);
+		return -EINVAL;
+	}
+
 	total_bytes = (total_bits + 7) >> 3;
 
-	buffer = kmalloc(total_bytes * 3, GFP_KERNEL);
+	buffer = kmalloc_array(total_bytes, 3, GFP_KERNEL);
 	if (!buffer) {
 		pr_info("OOM %u, op 0x%x, len %u bits, %u bytes.\n",
 			3 * total_bytes, opcode, total_bits, total_bytes);
@@ -152,6 +178,7 @@ static long xvc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 			total_bytes);
 	if (rv) {
 		pr_info("copy tmfs_buf failed: %d/%u.\n", rv, total_bytes);
+		rv = -EFAULT;
 		goto cleanup;
 	}
 	rv = copy_from_user((void *)tdi_buf,
@@ -159,6 +186,7 @@ static long xvc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 			total_bytes);
 	if (rv) {
 		pr_info("copy tdi_buf failed: %d/%u.\n", rv, total_bytes);
+		rv = -EFAULT;
 		goto cleanup;
 	}
 
@@ -209,8 +237,10 @@ static long xvc_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	}
 
 	rv = copy_to_user(xvc_obj.tdo_buf, (const void *)tdo_buf, total_bytes);
-	if (rv)
+	if (rv) {
 		pr_info("copy back tdo_buf failed: %d/%u.\n", rv, total_bytes);
+		rv = -EFAULT;
+	}
 
 unlock:
 #if HAS_MMIOWB

--- a/XDMA/linux-kernel/xdma/libxdma.c
+++ b/XDMA/linux-kernel/xdma/libxdma.c
@@ -49,7 +49,32 @@ MODULE_PARM_DESC(enable_st_c2h_credit,
 	"Set 1 to enable ST C2H engine credit feature, default is 0 ( credit control disabled)");
 
 unsigned int desc_blen_max = XDMA_DESC_BLEN_MAX;
-module_param(desc_blen_max, uint, 0644);
+
+/*
+ * desc_blen_max feeds the per-descriptor length, but the hardware bytes field
+ * is only XDMA_DESC_BLEN_BITS (28) wide. Since the parameter is writable at
+ * runtime (mode 0644), clamp every set so a value larger than the field width
+ * can never split scatterlist entries into oversized, truncated descriptors.
+ */
+static int desc_blen_max_set(const char *val, const struct kernel_param *kp)
+{
+	int rv = param_set_uint(val, kp);
+
+	if (rv)
+		return rv;
+	if (desc_blen_max > XDMA_DESC_BLEN_MAX) {
+		pr_info("desc_blen_max %u too large, clamping to %u.\n",
+			desc_blen_max, XDMA_DESC_BLEN_MAX);
+		desc_blen_max = XDMA_DESC_BLEN_MAX;
+	}
+	return 0;
+}
+
+static const struct kernel_param_ops desc_blen_max_ops = {
+	.set = desc_blen_max_set,
+	.get = param_get_uint,
+};
+module_param_cb(desc_blen_max, &desc_blen_max_ops, &desc_blen_max, 0644);
 MODULE_PARM_DESC(desc_blen_max,
 		 "per descriptor max. buffer length, default is (1 << 28) - 1");
 
@@ -216,7 +241,10 @@ static inline u32 build_u32(u32 hi, u32 lo)
 
 static inline u64 build_u64(u64 hi, u64 lo)
 {
-	return ((hi & 0xFFFFFFFULL) << 32) | (lo & 0xFFFFFFFFULL);
+	/* mask the high word to a full 32 bits; the literal used to be
+	 * 0xFFFFFFF (28 bits), which dropped bits 60-63 of the assembled value
+	 */
+	return ((hi & 0xFFFFFFFFULL) << 32) | (lo & 0xFFFFFFFFULL);
 }
 
 static void check_nonzero_interrupt_status(struct xdma_dev *xdev)
@@ -1226,8 +1254,18 @@ static void engine_service_work(struct work_struct *work)
 		goto unlock;
 	}
 
-	/* re-enable interrupts for this engine */
-	if (engine->xdev->msix_enabled) {
+	/* re-enable interrupts for this engine, unless the device/engine is being
+	 * taken offline. A work item queued by the ISR just before
+	 * xdma_device_offline()/close() can run after interrupts were
+	 * deliberately disabled; re-enabling here would undo that and race with
+	 * irq_teardown writing engine registers. Skip the re-enable when shutting
+	 * down.
+	 */
+	if (xdma_device_flag_check(engine->xdev, XDEV_FLAG_OFFLINE) ||
+	    (engine->shutdown & ENGINE_SHUTDOWN_REQUEST)) {
+		dbg_tfr("%s offline/shutdown, skip irq re-enable\n",
+			engine->name);
+	} else if (engine->xdev->msix_enabled) {
 		write_register(
 			engine->interrupt_enable_mask_value,
 			&engine->regs->interrupt_enable_mask_w1s,
@@ -1252,7 +1290,11 @@ static u32 engine_service_wb_monitor(struct xdma_engine *engine,
 
 	if (!engine) {
 		pr_err("dma engine NULL\n");
-		return -EINVAL;
+		/* return type is u32 (a writeback descriptor count); 0 means
+		 * "nothing serviced". The old "-EINVAL" became 0xFFFFFFEC. The
+		 * caller already guards against a NULL engine, so this is a
+		 * defensive path only. */
+		return 0;
 	}
 	wb_data = (struct xdma_poll_wb *)engine->poll_mode_addr_virt;
 
@@ -1376,7 +1418,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 	dbg_irq("(irq=%d, dev 0x%p) <<<< ISR.\n", irq, dev_id);
 	if (!dev_id) {
 		pr_err("Invalid dev_id on irq line %d\n", irq);
-		return -IRQ_NONE;
+		return IRQ_NONE;
 	}
 	xdev = (struct xdma_dev *)dev_id;
 
@@ -1455,7 +1497,7 @@ static irqreturn_t xdma_isr(int irq, void *dev_id)
 		}
 	}
 
-	xdev->irq_count++;
+	atomic_inc(&xdev->irq_count);
 	return IRQ_HANDLED;
 }
 
@@ -1523,7 +1565,7 @@ static irqreturn_t xdma_channel_irq(int irq, void *dev_id)
 	 * need to protect access here if multiple MSI-X are used for
 	 * user interrupts
 	 */
-	xdev->irq_count++;
+	atomic_inc(&xdev->irq_count);
 	return IRQ_HANDLED;
 }
 
@@ -1852,8 +1894,14 @@ static int enable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 
 		rv = pci_enable_msix(pdev, xdev->entry, req_nvec);
 #endif
-		if (rv < 0)
+		/* Only mark MSI-X enabled if vectors were actually allocated.
+		 * Setting the flag on failure made teardown paths keyed on
+		 * msix_enabled free vectors/IRQs that were never allocated.
+		 */
+		if (rv < 0) {
 			dbg_init("Couldn't enable MSI-X mode: %d\n", rv);
+			return rv;
+		}
 
 		xdev->msix_enabled = 1;
 
@@ -1862,8 +1910,10 @@ static int enable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 		/* enable message signalled interrupts */
 		dbg_init("pci_enable_msi()\n");
 		rv = pci_enable_msi(pdev);
-		if (rv < 0)
+		if (rv < 0) {
 			dbg_init("Couldn't enable MSI mode: %d\n", rv);
+			return rv;
+		}
 		xdev->msi_enabled = 1;
 
 	} else {
@@ -1982,6 +2032,10 @@ static void irq_msix_channel_teardown(struct xdma_dev *xdev)
 		dbg_sg("Release IRQ#%d for engine %p\n", engine->msix_irq_line,
 		       engine);
 		free_irq(engine->msix_irq_line, engine);
+		/* clear so this teardown is idempotent: it is invoked both from
+		 * the setup-failure rollback and from the normal teardown path
+		 */
+		engine->msix_irq_line = 0;
 	}
 
 	engine = xdev->engine_c2h;
@@ -1991,6 +2045,7 @@ static void irq_msix_channel_teardown(struct xdma_dev *xdev)
 		dbg_sg("Release IRQ#%d for engine %p\n", engine->msix_irq_line,
 		       engine);
 		free_irq(engine->msix_irq_line, engine);
+		engine->msix_irq_line = 0;
 	}
 }
 
@@ -2023,6 +2078,11 @@ static int irq_msix_channel_setup(struct xdma_dev *xdev)
 		if (rv) {
 			pr_info("requesti irq#%d failed %d, engine %s.\n",
 				vector, rv, engine->name);
+			/* free the channel IRQs requested so far before
+			 * returning, otherwise the caller frees the MSI-X
+			 * vectors with handlers still attached
+			 */
+			irq_msix_channel_teardown(xdev);
 			return rv;
 		}
 		pr_info("engine %s, irq#%d.\n", engine->name, vector);
@@ -2041,6 +2101,7 @@ static int irq_msix_channel_setup(struct xdma_dev *xdev)
 		if (rv) {
 			pr_info("requesti irq#%d failed %d, engine %s.\n",
 				vector, rv, engine->name);
+			irq_msix_channel_teardown(xdev);
 			return rv;
 		}
 		pr_info("engine %s, irq#%d.\n", engine->name, vector);
@@ -2193,8 +2254,15 @@ static int irq_setup(struct xdma_dev *xdev, struct pci_dev *pdev)
 		if (rv)
 			return rv;
 		rv = irq_msix_user_setup(xdev);
-		if (rv)
+		if (rv) {
+			/* user setup self-cleans its own IRQs, but the channel
+			 * IRQs from irq_msix_channel_setup() are still live;
+			 * free them so the caller does not free the MSI-X
+			 * vectors with handlers still attached
+			 */
+			irq_msix_channel_teardown(xdev);
 			return rv;
+		}
 		prog_irq_msix_channel(xdev, 0);
 		prog_irq_msix_user(xdev, 0);
 
@@ -2380,8 +2448,12 @@ static inline void xdma_desc_done(struct xdma_desc *desc_virt, int count)
 static void xdma_desc_set(struct xdma_desc *desc, dma_addr_t rc_bus_addr,
 			  u64 ep_addr, int len, int dir)
 {
-	/* transfer length */
-	desc->bytes = cpu_to_le32(len);
+	/* transfer length: the hardware bytes field is only XDMA_DESC_BLEN_BITS
+	 * (28) wide. Mask here so a desc_blen_max raised past the field width at
+	 * runtime (it is a writable module param) cannot write garbage upper
+	 * bits into the descriptor.
+	 */
+	desc->bytes = cpu_to_le32((u32)len & XDMA_DESC_BLEN_MAX);
 	if (dir == DMA_TO_DEVICE) {
 		/* read from root complex memory (source address) */
 		desc->src_addr_lo = cpu_to_le32(PCI_DMA_L(rc_bus_addr));
@@ -2621,6 +2693,16 @@ static int engine_destroy(struct xdma_dev *xdev, struct xdma_engine *engine)
 	if (poll_mode)
 		xdma_thread_remove_work(engine);
 
+	/* Flush any interrupt bottom-half already scheduled by the ISR before we
+	 * free the engine's resources. free_irq() (in irq_teardown, called before
+	 * remove_engines) only waits for the running hardirq, not for an already
+	 * queued engine->work item; without this, engine_service_work() could run
+	 * against the freed/zeroed engine below (use-after-free). Interrupts are
+	 * disabled above and the IRQ is freed before this point, so no new work
+	 * can be queued after the cancel.
+	 */
+	cancel_work_sync(&engine->work);
+
 	/* Release memory use for descriptor writebacks */
 	engine_free_resource(engine);
 
@@ -2743,7 +2825,6 @@ static int engine_init_regs(struct xdma_engine *engine)
 
 	/* Configure error interrupts by default */
 	reg_value = XDMA_CTRL_IE_DESC_ALIGN_MISMATCH;
-	reg_value |= XDMA_CTRL_IE_MAGIC_STOPPED;
 	reg_value |= XDMA_CTRL_IE_MAGIC_STOPPED;
 	reg_value |= XDMA_CTRL_IE_READ_ERROR;
 	reg_value |= XDMA_CTRL_IE_DESC_ERROR;
@@ -2888,16 +2969,30 @@ static int engine_init(struct xdma_engine *engine, struct xdma_dev *xdev,
 
 	rv = engine_alloc_resource(engine);
 	if (rv)
-		return rv;
+		goto err_init;
 
 	rv = engine_init_regs(engine);
-	if (rv)
-		return rv;
+	if (rv) {
+		/* free the resources just allocated before rolling back */
+		engine_free_resource(engine);
+		goto err_init;
+	}
 
 	if (poll_mode)
 		xdma_thread_add_work(engine);
 
 	return 0;
+
+err_init:
+	/* Roll back the bookkeeping done above so a half-initialized engine is
+	 * not left counted in engines_num and marked MAGIC_ENGINE (which would
+	 * make remove_engines try to tear down freed resources). engine_alloc_
+	 * resource() already freed/NULLed any partial allocation on its own
+	 * failure path.
+	 */
+	xdev->engines_num--;
+	engine->magic = 0;
+	return rv;
 }
 
 /* transfer_destroy() - free transfer */
@@ -3162,10 +3257,10 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 	struct xdma_request_cb *req = NULL;
 	struct scatterlist *sg;
 	enum dma_data_direction dir = write ? DMA_TO_DEVICE : DMA_FROM_DEVICE;
-	unsigned int maxlen = min_t(unsigned int, aperture, desc_blen_max);
+	unsigned int maxlen;
 	unsigned int sg_max;
 	unsigned int tlen = 0;
-	u64 ep_addr_max = ep_addr + aperture - 1;
+	u64 ep_addr_max;
 	ssize_t done = 0;
 	int i, rv = 0;
 
@@ -3173,6 +3268,24 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 		pr_err("dma engine NULL\n");
 		return -EINVAL;
 	}
+
+	/*
+	 * aperture is treated as a power-of-two window: it feeds maxlen and is
+	 * used as the bitmask (aperture - 1) when computing the per-pass
+	 * endpoint address. A zero aperture makes maxlen 0, so the outer loop
+	 * never advances req->offset and spins forever while holding desc_lock,
+	 * and ep_addr + aperture - 1 underflows. A non-power-of-two value makes
+	 * the (aperture - 1) mask produce wrong endpoint addresses. Reject both
+	 * before any size arithmetic uses the value.
+	 */
+	if (!aperture || (aperture & (aperture - 1))) {
+		pr_info("invalid aperture 0x%x (must be a power of two).\n",
+			aperture);
+		return -EINVAL;
+	}
+
+	maxlen = min_t(unsigned int, aperture, desc_blen_max);
+	ep_addr_max = ep_addr + aperture - 1;
 
 	if (engine->magic != MAGIC_ENGINE) {
 		pr_err("%s has invalid magic number %lx\n", engine->name,
@@ -3319,6 +3432,14 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 		
 		req->sg_offset = sg_offset;
 		req->sg_idx = i;
+		/* Persist the scatterlist cursor too. The inner for-loop resumes
+		 * from req->sg, but only req->sg_idx was being saved, so on a
+		 * second pass (transfer spanning more than one descriptor-ring
+		 * fill) sg restarted at sgt->sgl while i resumed mid-list,
+		 * rebuilding descriptors from already-transmitted entries. sg and
+		 * i advance together inside the loop, so save both here.
+		 */
+		req->sg = sg;
 
 		xfer->desc_adjacent = desc_cnt;
 		xfer->desc_num = desc_cnt;
@@ -3370,8 +3491,7 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 			goto unmap_sgl;
 		}
 
-		if (engine->cmplthp)
-			xdma_kthread_wakeup(engine->cmplthp);
+		xdma_engine_kthread_wakeup(engine);
 
 		if (timeout_ms > 0)
 			xlx_wait_event_interruptible_timeout(xfer->wq,
@@ -3434,7 +3554,14 @@ ssize_t xdma_xfer_aperture(struct xdma_engine *engine, bool write, u64 ep_addr,
 			break;
 		}
 
+		/* desc_used is read under engine->lock in engine_start() (to
+		 * program the C2H credit register); update it under the same
+		 * lock rather than relying on desc_lock, which engine_service
+		 * does not hold.
+		 */
+		spin_lock_irqsave(&engine->lock, flags);
 		engine->desc_used -= xfer->desc_num;
+		spin_unlock_irqrestore(&engine->lock, flags);
 		transfer_destroy(xdev, xfer);
 
 		if (rv < 0) {
@@ -3588,8 +3715,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			goto unmap_sgl;
 		}
 
-		if (engine->cmplthp)
-			xdma_kthread_wakeup(engine->cmplthp);
+		xdma_engine_kthread_wakeup(engine);
 
 		if (timeout_ms > 0)
 			xlx_wait_event_interruptible_timeout(xfer->wq,
@@ -3664,7 +3790,10 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			break;
 		}
 
+		/* update desc_used under engine->lock (see engine_start) */
+		spin_lock_irqsave(&engine->lock, flags);
 		engine->desc_used -= xfer->desc_num;
+		spin_unlock_irqrestore(&engine->lock, flags);
 		transfer_destroy(xdev, xfer);
 
 		/* use multiple transfers per request if we could not fit
@@ -3796,6 +3925,16 @@ ssize_t xdma_xfer_completion(void *cb_hndl, void *dev_hndl, int channel,
 		}
 
 		transfer_destroy(xdev, xfer);
+		/*
+		 * desc_used must be updated under engine->lock (it is read under
+		 * that lock in engine_start() to program the C2H credit register).
+		 * This function runs as the io_done completion callback, reached
+		 * from engine_transfer_completion() via engine_service() with
+		 * engine->lock already held by the caller (engine_service_work() /
+		 * engine_service_poll()). Re-acquiring the non-recursive
+		 * engine->lock here would self-deadlock the CPU, so update
+		 * desc_used directly under the lock already held.
+		 */
 		engine->desc_used -= xfer->desc_num;
 
 		tfer_idx++;
@@ -4036,6 +4175,12 @@ int xdma_performance_submit(struct xdma_dev *xdev, struct xdma_engine *engine)
 		       dev_name(&xdev->pdev->dev), engine->name);
 		goto err_engine_transfer;
 	}
+	/* Initialize the list node so the error path can safely test/remove it.
+	 * transfer_queue() links it onto engine->transfer_list only after some
+	 * of the failure points below, so the unwind must distinguish a queued
+	 * node from a never-queued one rather than list_del an empty node.
+	 */
+	INIT_LIST_HEAD(&transfer->entry);
 	/* 0 = write engine (to_dev=0) , 1 = read engine (to_dev=1) */
 	transfer->dir = engine->dir;
 	/* set number of descriptors */
@@ -4109,14 +4254,26 @@ int xdma_performance_submit(struct xdma_dev *xdev, struct xdma_engine *engine)
 	return 0;
 
 err_dma_desc:
-	if (free_desc && engine->desc)
-		dma_free_coherent(&xdev->pdev->dev,
+	/* Only free and clear engine->desc if this call allocated it. engine->desc
+	 * is normally pre-allocated at probe (engine_alloc_resource); clearing it
+	 * unconditionally orphaned that buffer (it is never freed later) and broke
+	 * subsequent transfers on the engine.
+	 */
+	if (free_desc) {
+		if (engine->desc)
+			dma_free_coherent(&xdev->pdev->dev,
 				num_desc_in_a_loop * sizeof(struct xdma_desc),
 				engine->desc, engine->desc_bus);
-	engine->desc = NULL;
+		engine->desc = NULL;
+	}
 err_engine_desc:
-	if (transfer)
-		list_del(&transfer->entry);
+	/* Remove from the engine transfer list only if it was actually queued.
+	 * list_del on a never-queued (but INIT_LIST_HEAD'd) node is a harmless
+	 * self-unlink with list_del_init; the original list_del on a kzalloc'd
+	 * (NULL next/prev) node dereferenced NULL.
+	 */
+	if (transfer && !list_empty(&transfer->entry))
+		list_del_init(&transfer->entry);
 	kfree(transfer);
 	transfer = NULL;
 err_engine_transfer:
@@ -4392,18 +4549,28 @@ static int probe_engines(struct xdma_dev *xdev)
 		return -EINVAL;
 	}
 
-	/* iterate over channels */
+	/* iterate over channels.
+	 * probe_for_engine() returns -EINVAL when no engine is present at a
+	 * channel (the normal loop terminator: trailing channels are absent),
+	 * but any other error (e.g. -ENOMEM from engine_init) is a real probe
+	 * failure that must abort device open rather than be silently swallowed
+	 * by truncating *_channel_max and returning success.
+	 */
 	for (i = 0; i < xdev->h2c_channel_max; i++) {
 		rv = probe_for_engine(xdev, DMA_TO_DEVICE, i);
-		if (rv)
+		if (rv == -EINVAL)
 			break;
+		else if (rv < 0)
+			return rv;
 	}
 	xdev->h2c_channel_max = i;
 
 	for (i = 0; i < xdev->c2h_channel_max; i++) {
 		rv = probe_for_engine(xdev, DMA_FROM_DEVICE, i);
-		if (rv)
+		if (rv == -EINVAL)
 			break;
+		else if (rv < 0)
+			return rv;
 	}
 	xdev->c2h_channel_max = i;
 

--- a/XDMA/linux-kernel/xdma/libxdma.h
+++ b/XDMA/linux-kernel/xdma/libxdma.h
@@ -609,7 +609,9 @@ struct xdma_dev {
 	int h2c_channel_max;
 
 	/* Interrupt management */
-	int irq_count;		/* interrupt counter */
+	atomic_t irq_count;	/* interrupt counter (incremented from
+				 * concurrent MSI-X handlers on different CPUs)
+				 */
 	int irq_line;		/* flag if irq allocated successfully */
 	int msi_enabled;	/* flag if msi was enabled for the device */
 	int msix_enabled;	/* flag if msi-x was enabled for the device */

--- a/XDMA/linux-kernel/xdma/xdma_cdev.c
+++ b/XDMA/linux-kernel/xdma/xdma_cdev.c
@@ -235,9 +235,16 @@ static int create_sys_device(struct xdma_cdev *xcdev, enum cdev_type type)
 		xcdev->cdevno, NULL, devnode_names[type], xdev->idx,
 		last_param);
 
-	if (!xcdev->sys_device) {
-		pr_err("device_create(%s) failed\n", devnode_names[type]);
-		return -1;
+	/* device_create() returns an ERR_PTR on failure, never NULL. The old
+	 * !NULL test never fired, so a failed create was treated as success and
+	 * the error pointer was later passed to device_destroy().
+	 */
+	if (IS_ERR(xcdev->sys_device)) {
+		int rv = PTR_ERR(xcdev->sys_device);
+
+		pr_err("device_create(%s) failed %d\n", devnode_names[type], rv);
+		xcdev->sys_device = NULL;
+		return rv;
 	}
 
 	return 0;
@@ -378,7 +385,14 @@ static int create_xcdev(struct xdma_pci_dev *xpdev, struct xdma_cdev *xcdev,
 del_cdev:
 	cdev_del(&xcdev->cdev);
 unregister_region:
-	unregister_chrdev_region(xcdev->cdevno, XDMA_MINOR_COUNT);
+	/* Do NOT unregister the chrdev region here. It is allocated once per
+	 * xdma_pci_dev as [MKDEV(major, XDMA_MINOR_BASE), XDMA_MINOR_COUNT] and
+	 * is released exactly once by xpdev_destroy_interfaces() (reached via the
+	 * caller's failure path). The old code called
+	 * unregister_chrdev_region(xcdev->cdevno, XDMA_MINOR_COUNT) with this
+	 * cdev's per-type minor as the base, releasing the wrong range and
+	 * corrupting the chrdev allocator.
+	 */
 	return rv;
 }
 

--- a/XDMA/linux-kernel/xdma/xdma_mod.c
+++ b/XDMA/linux-kernel/xdma/xdma_mod.c
@@ -167,6 +167,14 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		goto err_out;
 	}
 
+	/* Record the opened device handle now, before the validation/ISR steps
+	 * below. Their error paths goto err_out -> xpdev_free() ->
+	 * xdma_device_close(xpdev->xdev); if xpdev->xdev were still NULL there,
+	 * xdma_device_close() returns at its !dev_hndl guard and the opened
+	 * device (BAR maps, IRQ vectors, engine DMA buffers, pci regions) leaks.
+	 */
+	xpdev->xdev = hndl;
+
 	if (xpdev->user_max > MAX_USER_IRQ) {
 		pr_err("Maximum users limit reached\n");
 		rv = -EINVAL;
@@ -189,7 +197,10 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		pr_warn("NO engine found!\n");
 
 	if (xpdev->user_max) {
-		u32 mask = (1 << (xpdev->user_max + 1)) - 1;
+		/* user_max is the COUNT of user IRQ lines (0..user_max-1), so the
+		 * enable mask is (1 << user_max) - 1. The old "+ 1" set one extra
+		 * bit, enabling a user-IRQ line with no backing handler. */
+		u32 mask = (1 << xpdev->user_max) - 1;
 
 		rv = xdma_user_isr_enable(hndl, mask);
 		if (rv)
@@ -214,8 +225,6 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 		dev_name(&pdev->dev), xdev->idx, pdev, xpdev, xdev,
 		xpdev->user_max, xpdev->h2c_channel_max,
 		xpdev->c2h_channel_max);
-
-	xpdev->xdev = hndl;
 
 	rv = xpdev_create_interfaces(xpdev);
 	if (rv)

--- a/XDMA/linux-kernel/xdma/xdma_thread.c
+++ b/XDMA/linux-kernel/xdma/xdma_thread.c
@@ -49,13 +49,33 @@ static int xdma_thread_cmpl_status_pend(struct list_head *work_item)
 static int xdma_thread_cmpl_status_proc(struct list_head *work_item)
 {
 	struct xdma_engine *engine;
-	struct xdma_transfer * transfer;
+	struct xdma_transfer *transfer;
+	unsigned int desc_cmpl_th = 0;
+	unsigned long flags;
+	int have_xfer = 0;
 
 	engine = list_entry(work_item, struct xdma_engine, cmplthp_list);
-	transfer = list_entry(engine->transfer_list.next, struct xdma_transfer,
-			entry);
-	if (transfer)
-		engine_service_poll(engine, transfer->desc_cmpl_th);
+
+	/*
+	 * Inspect the transfer list under engine->lock. The old code read
+	 * engine->transfer_list.next without the lock (racing enqueue/dequeue,
+	 * a use-after-free on a transfer being freed) and tested the result for
+	 * NULL: list_entry() on the list head is pointer arithmetic and is never
+	 * NULL, so on an empty list it dereferenced a bogus transfer overlapping
+	 * the engine. Snapshot desc_cmpl_th under the lock and only poll when a
+	 * transfer is actually queued.
+	 */
+	spin_lock_irqsave(&engine->lock, flags);
+	if (!list_empty(&engine->transfer_list)) {
+		transfer = list_first_entry(&engine->transfer_list,
+					    struct xdma_transfer, entry);
+		desc_cmpl_th = transfer->desc_cmpl_th;
+		have_xfer = 1;
+	}
+	spin_unlock_irqrestore(&engine->lock, flags);
+
+	if (have_xfer)
+		engine_service_poll(engine, desc_cmpl_th);
 	return 0;
 }
 
@@ -102,7 +122,7 @@ static int xthread_main(void *data)
 
 	while (!kthread_should_stop()) {
 
-		struct list_head *work_item, *next;
+		struct list_head *work_item;
 
 		pr_debug_thread("%s interruptible\n", thp->name);
 
@@ -118,11 +138,27 @@ static int xthread_main(void *data)
 		if (thp->work_cnt) {
 			pr_debug_thread("%s processing %u work items\n",
 					thp->name, thp->work_cnt);
-			/* do work */
-			list_for_each_safe(work_item, next, &thp->work_list) {
+			/*
+			 * Process one work item per locked critical section,
+			 * re-reading the list head each iteration. The old code
+			 * cached the list_for_each_safe 'next' cursor once and
+			 * dropped the lock across fproc(); a concurrent
+			 * xdma_thread_remove_work()/add_work() could then free or
+			 * relink that cached node, sending the traversal off a
+			 * poisoned pointer. work_running publishes the in-flight
+			 * node so remove_work() can wait for fproc to finish
+			 * before the engine is freed.
+			 */
+			list_for_each(work_item, &thp->work_list) {
+				thp->work_running = work_item;
 				unlock_thread(thp);
 				thp->fproc(work_item);
 				lock_thread(thp);
+				thp->work_running = NULL;
+				/* the list may have changed while unlocked;
+				 * restart from the (current) head
+				 */
+				break;
 			}
 		}
 		unlock_thread(thp);
@@ -231,10 +267,44 @@ void xdma_thread_remove_work(struct xdma_engine *engine)
 
 	if (cmpl_thread) {
 		lock_thread(cmpl_thread);
+		/*
+		 * Wait out any fproc currently servicing this engine before
+		 * unlinking it. xthread_main drops the thread lock across
+		 * fproc() and publishes the in-flight node in work_running; if
+		 * we removed the node and let engine_destroy() free/memset the
+		 * engine while fproc still held it, the worker would touch freed
+		 * memory (use-after-free). work_running is cleared under the
+		 * thread lock once fproc returns, so re-checking it here is safe.
+		 */
+		while (cmpl_thread->work_running == &engine->cmplthp_list) {
+			unlock_thread(cmpl_thread);
+			schedule();
+			lock_thread(cmpl_thread);
+		}
 		list_del(&engine->cmplthp_list);
 		cmpl_thread->work_cnt--;
 		unlock_thread(cmpl_thread);
 	}
+}
+
+void xdma_engine_kthread_wakeup(struct xdma_engine *engine)
+{
+	struct xdma_kthread *thp;
+	unsigned long flags;
+
+	/*
+	 * Read engine->cmplthp under engine->lock. Callers used to test
+	 * engine->cmplthp and then deref it unlocked; xdma_thread_remove_work()
+	 * clears it (and engine_destroy() then frees the kthread/engine state)
+	 * under the same lock, so the unlocked check-then-use raced into a
+	 * write-after-free on the kthread struct. Holding the lock across the
+	 * read closes that window.
+	 */
+	spin_lock_irqsave(&engine->lock, flags);
+	thp = engine->cmplthp;
+	if (thp)
+		xdma_kthread_wakeup(thp);
+	spin_unlock_irqrestore(&engine->lock, flags);
 }
 
 void xdma_thread_add_work(struct xdma_engine *engine)

--- a/XDMA/linux-kernel/xdma/xdma_thread.h
+++ b/XDMA/linux-kernel/xdma/xdma_thread.h
@@ -98,6 +98,11 @@ struct xdma_kthread {
 	unsigned int work_cnt;
 	/**  thread work list count */
 	struct list_head work_list;
+	/**  work item currently being processed by fproc (lock dropped), or
+	 *   NULL when idle. Protected by ->lock. Lets xdma_thread_remove_work()
+	 *   wait for an in-flight fproc before the engine is freed.
+	 */
+	struct list_head *work_running;
 	/**  thread initialization handler */
 	int (*finit)(struct xdma_kthread *);
 	/**  thread pending handler */
@@ -143,6 +148,18 @@ void xdma_thread_remove_work(struct xdma_engine *engine);
  * @return	none
  *****************************************************************************/
 void xdma_thread_add_work(struct xdma_engine *engine);
+
+/*****************************************************************************/
+/**
+ * xdma_engine_kthread_wakeup() - wake an engine's completion-status thread,
+ *	reading engine->cmplthp under engine->lock to avoid a check-then-use
+ *	race against xdma_thread_remove_work().
+ *
+ * @param[in]	engine:	pointer to xdma_engine
+ *
+ * @return	none
+ *****************************************************************************/
+void xdma_engine_kthread_wakeup(struct xdma_engine *engine);
 
 int xdma_kthread_start(struct xdma_kthread *thp, char *name, int id);
 int xdma_kthread_stop(struct xdma_kthread *thp);


### PR DESCRIPTION
Two audit passes over the XDMA Linux kernel driver surfaced 46 confirmed defects across memory safety, concurrency/teardown, DMA/descriptor handling, user-input validation, error-path resource management, and IRQ/perf/bypass handling. This change fixes all of them and adds host-compiled logic proofs for the arithmetic/pointer bug classes. Each fix is tagged with its audit id.

The driver builds clean (zero warnings) against kernel 6.8.0. The synchronous memory-mapped read/write path was exercised on hardware with repeated multi-channel write-read-verify transfers, with no data mismatches and no kernel errors observed.

## PASS 1 - 30 audited defects

### Critical

- C1 cdev_xvc.c: validate user xvc_obj.length (reject 0, cap to XVC_MAX_BITS) and use kmalloc_array; the old (total_bits+7)>>3 and *3 unsigned math wrapped into an undersized allocation -> user-controlled kernel heap overflow.
- C2 cdev_sgdma.c: async_io_handler freed an interior/array pointer (&caio->cb[i]) and never freed the caio->cb array; free the array base once on the final completion, and in the skip_dev_lock path.

### High

- H1 libxdma.c: INIT_LIST_HEAD the perf transfer and list_del_init only if queued, instead of list_del on a never-queued (NULL) node -> NULL deref.
- H2 libxdma.c: only clear engine->desc when this call allocated it; avoids orphaning the pre-allocated coherent descriptor buffer.
- H3 libxdma.c: cancel_work_sync(&engine->work) in engine_destroy before freeing/zeroing the engine -> closes ISR bottom-half use-after-free.
- H4 libxdma.c: persist req->sg alongside req->sg_idx in xdma_xfer_aperture so multi-pass transfers resume from the correct scatterlist entry (was rebuilding descriptors from already-sent entries -> data corruption).
- H5 libxdma.c: reject aperture 0 / non-power-of-two -> prevents infinite loop holding desc_lock (DoS) and endpoint-address underflow.
- H6 libxdma.c: probe_engines distinguishes "no engine" (-EINVAL terminator) from real engine_init failures, which now abort open; engine_init rolls back magic/engines_num and frees resources on failure.
- H7 cdev_sgdma.c: validate/pin/map all AIO segments before submitting any; failure now cleans up synchronously instead of leaking caio/cb/sgt/pages, hanging the iocb, or freeing caio with transfers in flight.
- H8 cdev_sgdma.c: skip_dev_lock completion passes -EBUSY instead of reading uninitialized res/res2 on RHEL >= 9 (kernel-stack info leak).
- H9 cdev_ctrl.c: bound the user *pos against the mapped BAR length in the ctrl register read/write paths -> prevents out-of-bounds MMIO.
- H10 cdev_ctrl.c: validate the mmap offset against the BAR length; the old psize subtraction underflowed and let userspace map past the BAR.
- H11/M6 libxdma.c: make the MSI-X setup helpers self-cleaning (free already-requested channel IRQs on failure) and idempotent; avoids freeing MSI-X vectors with handlers still attached on probe failure.
- H12/H13/L5 xdma_thread.c: process one work item per locked critical section (no cached cursor across the unlocked fproc), publish the in-flight node so xdma_thread_remove_work waits for it before the engine is freed, and add a locked xdma_engine_kthread_wakeup() used by all wakers.
- H14 cdev_bypass.c: copy user data through a kernel bounce buffer outside engine->lock (a spinlock); copy_to/from_user under it could sleep.

### Medium

- M1 cdev_sgdma.c: bound the AIO iovec count, NULL-check kmem_cache_alloc, use kcalloc for the cb array.
- M2 cdev_sgdma.c: check copy_from_user != 0 (not < 0) in the perf and aperture ioctls.
- M3 cdev_sgdma.c: atomic test-and-set of engine->device_open under engine->lock in open/close.
- M4 libxdma.c: engine_service_work skips re-enabling interrupts when the device is offline / engine shutting down.
- M5 libxdma.c: update engine->desc_used under engine->lock at all decrement sites (matches the read in engine_start for the C2H credit register).
- M7 xdma_cdev.c: use IS_ERR on device_create.
- M8 xdma_cdev.c: do not unregister the per-xpdev chrdev region in the per-cdev error path (it was using the wrong minor base/count).
- M9 xdma_thread.c: inspect transfer_list under engine->lock with list_empty + list_first_entry instead of a never-NULL list_entry on the head.

### Low

- L1 libxdma.c: build_u64 high-word mask 0xFFFFFFF -> 0xFFFFFFFF (28 -> 32 bits).
- L2 libxdma.c: clamp desc_blen_max via a module_param_cb set callback and mask the length to XDMA_DESC_BLEN_MAX in xdma_desc_set.
- L3 libxdma.c/.h: make xdev->irq_count an atomic_t.
- L4 libxdma.c: set msi/msix_enabled only after the vectors are allocated.

Also bakes the AWS F2 device ids (0x1d0f:0xf004, 0x1d0f:0x9048) into the pci_ids table so the driver binds without runtime source edits, and adds tests/bug_logic_proofs/: host-compiled assertions proving the arithmetic/pointer bug classes (C1, C2, H4, H5, M2, L1, L2) on the original vs fixed logic.

## PASS 2 - 16 more audited defects

### Concurrency / use-after-free

- P1 libxdma.c xdma_xfer_completion: the M5 fix (above) re-acquired engine->lock in the completion callback, but that callback already runs from engine_transfer_completion() with engine->lock held by engine_service_work()/engine_service_poll(). Re-acquiring a non-recursive spinlock on the same CPU self-deadlocks (IRQs disabled) on the first completion of any async transfer. Update desc_used directly under the lock the caller already holds. (Regression introduced by M5; caught before release.)
- P2 cdev_sgdma.c ioctl_do_perf_stop: engine_cyclic_stop() was called with no lock (its contract requires engine->lock) and engine->xdma_perf was freed unlocked, racing engine_service_perf()/engine_service_work() which read xdma_perf and walk transfer_list under the lock -> use-after-free / double list_del. Take engine->lock around engine_cyclic_stop(), then cancel_work_sync() the engine work (outside the lock, since it may sleep) before freeing xdma_perf and the transfer. (Covers the perf-stop list race and the xdma_perf lifetime race.)

### Resource leaks

- P3 cdev_sgdma.c ioctl_do_perf_start: engine->xdma_perf was kzalloc'd then leaked on three error returns (copy_from_user fault, version mismatch, xdma_performance_submit failure) with no kfree/NULL, and because the pointer stayed set the "already running" guard then wedged the perf interface at -EBUSY permanently. Free and NULL it on every post-allocation error path.
- P4 cdev_sgdma.c ioctl_do_perf_stop: on a copy_to_user failure the function returned before kfree(transfer), leaking the cyclic transfer struct engine_cyclic_stop() had unlinked and handed back. Free it before returning, and return -EFAULT.
- P5 cdev_sgdma.c char_sgdma_map_user_buf_to_sgl: the post-loop residual-length guard returned -EINVAL before setting cb->pages_nr, so the caller's unmap was a no-op and the pinned pages + sg table leaked. Record pages_nr and goto the cleanup label. (Defensive; not reachable on the common path, but now correct.)
- P6 xdma_mod.c probe_one: xpdev->xdev was assigned only just before xpdev_create_interfaces(), so every earlier "goto err_out" ran xpdev_free() -> xdma_device_close(pdev, NULL), which returns at its !dev_hndl guard and never releases the device opened by xdma_device_open() -> leak of BAR mappings, IRQ vectors, engine DMA buffers and pci regions on each failed probe. Assign xpdev->xdev immediately after the open succeeds.

### User-input / errno correctness

- P7 cdev_sgdma.c ioctl_do_aperture_dma: the result copy_to_user was checked with "if (rv < 0)", which is unreachable (copy_to_user returns bytes-not-copied, never negative), so a copy-back fault was reported to userspace as success. Test != 0 and return -EFAULT (the same class M2 fixed for copy_from_user).
- P8 cdev_xvc.c xvc_ioctl: the xvc_obj/tms_buf/tdi_buf copy_from_user paths and the tdo_buf copy_to_user path returned the positive bytes-not-copied count as the ioctl result instead of an error. Translate every copy failure to -EFAULT.
- P9 cdev_ctrl.c char_ctrl_read/char_ctrl_write: the handlers ignored the caller-supplied count and always transferred 4 bytes, so a sub-4-byte read()/write() over-wrote/over-read the user buffer (the sibling char_events_read already guards with count != 4). Require count == 4 and return -EFAULT on a copy fault.
- P10 cdev_ctrl.c char_ctrl_write: on a copy_from_user fault the code logged "but continuing" and then iowrite32()'d an uninitialized stack value to the BAR register and returned success. Return -EFAULT and skip the register write so stack garbage is never pushed to hardware.

### DMA addressing

- P11 cdev_bypass.c char_bypass_write: engine->bypass_offset is a byte offset (engines_num * BYPASS_MODE_SPACING), but it was added to a (u32 __iomem *), scaling it by 4 -> every engine past channel 0 wrote its descriptor DWORDs to bar + bypass_offset*4 instead of bar + bypass_offset, corrupting the bypass descriptor stream. Add the byte offset to the void __iomem * base directly.

### IRQ

- P12 xdma_mod.c probe_one: the user-interrupt enable mask was (1 << (user_max + 1)) - 1, one bit too wide (user_max is a count, not a max index), enabling a user IRQ line with no registered handler. Use (1 << user_max) - 1.

### Cosmetic / dead-path (no behavior change on reachable paths)

- P13 libxdma.c xdma_isr: "return -IRQ_NONE" negated an irqreturn_t enum (it equaled IRQ_NONE only by luck). Return IRQ_NONE.
- P14 libxdma.c engine_init_regs: XDMA_CTRL_IE_MAGIC_STOPPED was OR'd into reg_value twice; drop the redundant line.
- P15 libxdma.c engine_service_wb_monitor: declared u32 but returned -EINVAL (0xFFFFFFEC) on the defensive NULL-engine path; return 0. The caller already guards against a NULL engine.