### PR TITLE
QDMA: Fix read_iter/write_iter operations and interrupt handling

### DIFF
--- a/QDMA/linux-kernel/apps/dma-perf/dmaperf.c
+++ b/QDMA/linux-kernel/apps/dma-perf/dmaperf.c
@@ -1349,7 +1349,7 @@ static void *event_mon(void *argp)
 					printf("Error: Invalid IOCB from events\n");
 					continue;
 				}
-				_info->num_req_completed += events[j].res;
+				_info->num_req_completed += iocb->u.c.nbytes; // iovec count, for preadv/pwritev
 
 				iov = (struct iovec *)(iocb->u.c.buf);
 				if (!iov) {

--- a/QDMA/linux-kernel/apps/dma-utils/dmaxfer.c
+++ b/QDMA/linux-kernel/apps/dma-utils/dmaxfer.c
@@ -485,7 +485,7 @@ static void *event_mon(void *handle)
 					printf("Error: Invalid IOCB from events\n");
 					continue;
 				}
-				_info->num_req_completed += events[j].res;
+				_info->num_req_completed += iocb->u.c.nbytes; // iovec count, for preadv/pwritev
 
 				iov = (struct iovec *)(iocb->u.c.buf);
 				if (!iov) {

--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
@@ -2465,6 +2465,8 @@ ssize_t qdma_request_submit(unsigned long dev_hndl, unsigned long id,
 	/** Initialize the wait queue */
 	qdma_waitq_init(&cb->wq);
 
+	cb->left = req->count;
+
 	pr_debug("%s: data len %u, ep 0x%llx, sgl 0x%p, sgl cnt %u, tm %u ms.\n",
 		descq->conf.name, req->count, req->ep_addr, req->sgl,
 		req->sgcnt, req->timeout_ms);
@@ -2508,11 +2510,13 @@ ssize_t qdma_request_submit(unsigned long dev_hndl, unsigned long id,
 	if (rv < 0)
 		goto unmap_sgl;
 
-	return cb->offset;
+	return rv;
 
 unmap_sgl:
-	if (!req->dma_mapped)
+	if (cb->unmap_needed) {
 		sgl_unmap(xdev->conf.pdev,  req->sgl, req->sgcnt, dir);
+		cb->unmap_needed = 0;
+	}
 
 	return rv;
 }
@@ -2523,6 +2527,12 @@ unmap_sgl:
  *  for dma operation (for both read and write)
  * This is a callback function called from upper layer(character device)
  * to handle the read/write request on the queues
+ * 
+ * If qdma_batch_request_submit fails during DMA mapping, it unwinds mapped
+ * requests and returns an error before enqueueing anything.
+ *
+ * Once requests are added to descq->work_list, normal completion should
+ * eventually call ki_complete through fp_done (qdma_req_completed).
  *
  * @param[in]	dev_hndl:	hndl retured from qdma_device_open()
  * @param[in]	id:			queue index
@@ -2541,6 +2551,7 @@ ssize_t qdma_batch_request_submit(unsigned long dev_hndl, unsigned long id,
 	enum dma_data_direction dir;
 	int rv = 0;
 	unsigned long i;
+	unsigned long mapped = 0;
 	struct qdma_request *req;
 	int st_c2h = 0;
 
@@ -2622,10 +2633,11 @@ ssize_t qdma_batch_request_submit(unsigned long dev_hndl, unsigned long id,
 						descq->conf.name,
 						req->sgcnt,
 						req->count);
-					req->fp_done(req, 0, rv);
+					goto unmap_mapped;
 				}
 				cb->unmap_needed = 1;
 			}
+			mapped++;
 		}
 	}
 
@@ -2635,7 +2647,8 @@ ssize_t qdma_batch_request_submit(unsigned long dev_hndl, unsigned long id,
 		unlock_descq(descq);
 		pr_err("%s descq %s NOT online.\n", xdev->conf.name,
 				descq->conf.name);
-		return -EINVAL;
+		rv = -EINVAL;
+		goto unmap_mapped;
 	}
 
 	for (i = 0; i < count; i++) {
@@ -2649,6 +2662,19 @@ ssize_t qdma_batch_request_submit(unsigned long dev_hndl, unsigned long id,
 	qdma_descq_proc_sgt_request(descq);
 
 	return 0;
+
+unmap_mapped:
+	for (i = 0; i < mapped; i++) {
+		req = reqv[i];
+		cb = qdma_req_cb_get(req);
+
+		if (cb->unmap_needed) {
+			sgl_unmap(xdev->conf.pdev, req->sgl, req->sgcnt, dir);
+			cb->unmap_needed = 0;
+		}
+	}
+
+	return rv;
 }
 
 #ifdef TANDEM_BOOT_SUPPORTED

--- a/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_export.c
@@ -247,6 +247,8 @@ static int qdma_request_wait_for_cmpl(struct xlnx_dma_dev *xdev,
 			struct qdma_descq *descq, struct qdma_request *req)
 {
 	struct qdma_sgt_req_cb *cb = qdma_req_cb_get(req);
+	unsigned long now, timeout, expire;
+	int rv;
 
 	/** if timeout is mentioned in the request,
 	 *  wait until the timeout occurs or wait until the
@@ -254,19 +256,33 @@ static int qdma_request_wait_for_cmpl(struct xlnx_dma_dev *xdev,
 	 */
 
 	if (req->timeout_ms) {
-#ifdef __XRT__
-		qdma_waitq_wait_event_timeout(cb->wq, cb->done &&
-				(descq->pidx == descq->cidx),
-				msecs_to_jiffies(req->timeout_ms));
-#else
-		qdma_waitq_wait_event_timeout(cb->wq, cb->done,
-				msecs_to_jiffies(req->timeout_ms));
-#endif
+		now = jiffies;
+		timeout = msecs_to_jiffies(req->timeout_ms);
+		expire = now + timeout;
+		do {
+			#ifdef __XRT__
+			rv = qdma_waitq_wait_event_timeout(cb->wq, cb->done &&
+					(descq->pidx == descq->cidx),
+					timeout);
+			#else
+			rv = qdma_waitq_wait_event_timeout(cb->wq, cb->done,
+					timeout);
+			#endif
+			if (rv >= 0)
+				break;
+			now = jiffies;
+			if (unlikely(now >= expire))
+				break;
+			timeout = expire - now;
+		} while (1);
 	} else {
-		qdma_waitq_wait_event(cb->wq, cb->done);
+		do {
+			rv = qdma_waitq_wait_event(cb->wq, cb->done);
+		} while (rv < 0);
 	}
 
 	lock_descq(descq);
+
 	/** if the call back is not done, request timed out
 	 *  delete the request list
 	 */
@@ -276,7 +292,7 @@ static int qdma_request_wait_for_cmpl(struct xlnx_dma_dev *xdev,
 	/** if the call back is not done but the status is updated
 	 *  return i/o error
 	 */
-	if (!cb->done || cb->status) {
+	if (unlikely(!cb->done || cb->status)) {
 		pr_err("%s: req 0x%p, %c,%u,%u/%u,0x%llx, done %d, err %d, tm %u.\n",
 				descq->conf.name,
 				req, req->write ? 'W' : 'R',
@@ -288,13 +304,13 @@ static int qdma_request_wait_for_cmpl(struct xlnx_dma_dev *xdev,
 				cb->status,
 			req->timeout_ms);
 		qdma_descq_dump(descq, NULL, 0, 1);
-		unlock_descq(descq);
-
-		return -EIO;
+		rv = -EIO;
+	} else {
+		rv = req->count;
 	}
 
 	unlock_descq(descq);
-	return 0;
+	return rv;
 }
 
 /*****************************************************************************/

--- a/QDMA/linux-kernel/driver/src/cdev.c
+++ b/QDMA/linux-kernel/driver/src/cdev.c
@@ -61,6 +61,7 @@ static LIST_HEAD(xlnx_phy_dev_list);
 static DEFINE_MUTEX(xlnx_phy_dev_mutex);
 
 struct cdev_async_io {
+	ssize_t res;
 	ssize_t res2;
 	unsigned long req_count;
 	unsigned long cmpl_count;
@@ -129,15 +130,20 @@ static int qdma_req_completed(struct qdma_request *req,
 
 	unmap_user_buf(qiocb, req->write);
 	iocb_release(qiocb);
-	caio->res2 |= (err < 0) ? err : 0;
-	if (caio->res2)
+	if (err < 0) {
+		if (!(caio->res2))
+			caio->res2 = err; // return the first error
 		caio->err_cnt++;
+	} else if (!(caio->res2)) {
+		caio->res += bytes_done; // add the iovec byte count; return the successful byte count before the first error
+	}
 	caio->cmpl_count++;
 	if (caio->cmpl_count == caio->req_count) {
-		res = caio->cmpl_count - caio->err_cnt;
+		res = caio->res;
 		res2 = caio->res2;
 #ifdef RHEL_RELEASE_VERSION
 #if RHEL_RELEASE_VERSION(9, 0) < RHEL_RELEASE_CODE
+		res = (res2 < 0) ? res2 : res;
 		caio->iocb->ki_complete(caio->iocb, res);
 #elif RHEL_RELEASE_VERSION(8, 0) < RHEL_RELEASE_CODE
 		caio->iocb->ki_complete(caio->iocb, res, res2);
@@ -146,6 +152,7 @@ static int qdma_req_completed(struct qdma_request *req,
 #endif
 #else
 #if KERNEL_VERSION(5, 16, 0) <= LINUX_VERSION_CODE
+		res = (res2 < 0) ? res2 : res;
 		caio->iocb->ki_complete(caio->iocb, res);
 #elif KERNEL_VERSION(4, 1, 0) <= LINUX_VERSION_CODE
 		caio->iocb->ki_complete(caio->iocb, res, res2);
@@ -470,7 +477,7 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		caio->reqv[i]->ep_addr = (u64)pos;
 		pos += io[i].iov_len;
 		caio->reqv[i]->no_memcpy = xcdev->no_memcpy ? 1 : 0;
-		caio->reqv[i]->count = io->iov_len;
+		caio->reqv[i]->count = io[i].iov_len;
 		caio->reqv[i]->timeout_ms = 10 * 1000;	/* 10 seconds */
 		caio->reqv[i]->fp_done = qdma_req_completed;
 
@@ -545,7 +552,7 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 		caio->reqv[i]->ep_addr = (u64)pos;
 		pos += io[i].iov_len;
 		caio->reqv[i]->no_memcpy = xcdev->no_memcpy ? 1 : 0;
-		caio->reqv[i]->count = io->iov_len;
+		caio->reqv[i]->count = io[i].iov_len;
 		caio->reqv[i]->timeout_ms = 10 * 1000;	/* 10 seconds */
 		caio->reqv[i]->fp_done = qdma_req_completed;
 	}

--- a/QDMA/linux-kernel/driver/src/cdev.c
+++ b/QDMA/linux-kernel/driver/src/cdev.c
@@ -275,6 +275,25 @@ static void unmap_user_buf(struct qdma_io_cb *iocb, bool write)
 	iocb->pages_nr = 0;
 }
 
+static void cdev_async_io_cleanup(struct cdev_async_io *caio,
+		unsigned long count, bool write)
+{
+	unsigned long i;
+
+	if (!caio)
+		return;
+
+	if (caio->qiocb) {
+		for (i = 0; i < count; i++) {
+			unmap_user_buf(&caio->qiocb[i], write);
+			iocb_release(&caio->qiocb[i]);
+		}
+		kfree(caio->qiocb);
+	}
+
+	kmem_cache_free(cdev_cache, caio);
+}
+
 static int map_user_buf_to_sgl(struct qdma_io_cb *iocb, bool write)
 {
 	unsigned long len = iocb->len;
@@ -456,6 +475,7 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 			sizeof(struct qdma_request *)), GFP_KERNEL);
 	if (!caio->qiocb) {
 		pr_err("failed to allocate qiocb");
+		cdev_async_io_cleanup(caio, 0, true);
 		return -ENOMEM;
 	}
 
@@ -482,7 +502,7 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 		caio->reqv[i]->fp_done = qdma_req_completed;
 
 	}
-	if (i > 0) {
+	if (!rv && i == count) {
 		iocb->private = caio;
 		caio->iocb = iocb;
 		caio->req_count = i;
@@ -491,10 +511,13 @@ static ssize_t cdev_aio_write(struct kiocb *iocb, const struct iovec *io,
 				     caio->req_count, caio->reqv);
 		if (rv >= 0)
 			rv = -EIOCBQUEUED;
+		else {
+			iocb->private = NULL;
+			cdev_async_io_cleanup(caio, caio->req_count, true);
+		}
 	} else {
 		pr_err("failed with %d for %lu reqs", rv, caio->req_count);
-		kfree(caio->qiocb);
-		kmem_cache_free(cdev_cache, caio);
+		cdev_async_io_cleanup(caio, i, true);
 	}
 
 	return rv;
@@ -524,6 +547,7 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 	caio = kmem_cache_alloc(cdev_cache, GFP_KERNEL);
 	if (!caio) {
 		pr_err("failed to allocate qiocb");
+		cdev_async_io_cleanup(caio, 0, false);
 		return -ENOMEM;
 	}
 	memset(caio, 0, sizeof(struct cdev_async_io));
@@ -556,7 +580,7 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 		caio->reqv[i]->timeout_ms = 10 * 1000;	/* 10 seconds */
 		caio->reqv[i]->fp_done = qdma_req_completed;
 	}
-	if (i > 0) {
+	if (!rv && i == count) {
 		iocb->private = caio;
 		caio->iocb = iocb;
 		caio->req_count = i;
@@ -565,10 +589,13 @@ static ssize_t cdev_aio_read(struct kiocb *iocb, const struct iovec *io,
 				     caio->req_count, caio->reqv);
 		if (rv >= 0)
 			rv = -EIOCBQUEUED;
+		else {
+			iocb->private = NULL;
+			cdev_async_io_cleanup(caio, caio->req_count, false);
+		}
 	} else {
 		pr_err("failed with %d for %lu reqs", rv, caio->req_count);
-		kfree(caio->qiocb);
-		kmem_cache_free(cdev_cache, caio);
+		cdev_async_io_cleanup(caio, i, false);
 	}
 
 	return rv;


### PR DESCRIPTION
QDMA: Fix read_iter/write_iter operations:
* Update `qdma_req_completed` function to return data byte length instead of iovec count
* Update `cdev_aio_write` and `cdev_aio_read` functions to fix `count` assigned to each `qdma_request`
* Update `dmaperf` and `dmaxfer` apps to account for `num_req_completed` using request iovec count instead of response data byte length

QDMA: Continue awaiting completion after interrupts
* Update `qdma_request_wait_for_cmpl` function to continue waiting after interrupts

QDMA: Unmap partial requests and skip submission after mapping errors
* Update `qdma_request_submit` function to unmap SGL based on `unmap_needed` flag instead of `dma_mapped`
* Update `qdma_batch_request_submit` to unmap SGLs if a request mapping occurs, without enqueueing partial requests
* Add `cdev_async_io_cleanup` function to cleanup unmap user buffers and clear `cdev_async_io`
* Update `cdev_aio_write` and `cdev_aio_read` functions to call `cdev_async_io_cleanup` if a request mapping occurs