### PR TITLE
libqdma: fix bugs with the QDMA_CSR_REG_UPDATE code

### DIFF
--- a/QDMA/linux-kernel/driver/libqdma/libqdma_config.c
+++ b/QDMA/linux-kernel/driver/libqdma/libqdma_config.c
@@ -160,7 +160,7 @@ int qdma_set_intr_rngsz(unsigned long dev_hndl, u32 intr_rngsz)
 	/** If qdma_get_active_queue_count() > 0,
 	 *  intr_rngsz is not allowed to change.
 	 */
-	if (qdma_get_active_queue_count(xdev->conf.pdev->bus->number)) {
+	if (qdma_get_active_queue_count(xdev->dma_device_index)) {
 		pr_err("xdev 0x%p, FMAP prog done, cannot modify intr ring size [%d]\n",
 				xdev,
 				xdev->conf.intr_rngsz);
@@ -253,7 +253,7 @@ int qdma_set_buf_sz(unsigned long dev_hndl, u32 *buf_sz)
 	/** If qdma_get_active_queue_count() > 0,
 	 *  buf_sz is not allowed to change.
 	 */
-	if (qdma_get_active_queue_count(xdev->conf.pdev->bus->number)) {
+	if (qdma_get_active_queue_count(xdev->dma_device_index)) {
 		pr_err("xdev 0x%p, FMAP prog done, cannot modify buf size\n",
 				xdev);
 		return rv;
@@ -332,7 +332,7 @@ int qdma_set_glbl_rng_sz(unsigned long dev_hndl, u32 *glbl_rng_sz)
 	/** If qdma_get_active_queue_count() > 0,
 	 *  glbl_rng_sz is not allowed to change.
 	 */
-	if (qdma_get_active_queue_count(xdev->conf.pdev->bus->number)) {
+	if (qdma_get_active_queue_count(xdev->dma_device_index)) {
 		pr_err("xdev 0x%p, FMAP prog done, cannot modify glbl_rng_sz\n",
 				xdev);
 		return rv;
@@ -411,7 +411,7 @@ int qdma_set_timer_cnt(unsigned long dev_hndl, u32 *tmr_cnt)
 	/** If qdma_get_active_queue_count() > 0,
 	 *  tmr_cnt is not allowed to change.
 	 */
-	if (qdma_get_active_queue_count(xdev->conf.pdev->bus->number)) {
+	if (qdma_get_active_queue_count(xdev->dma_device_index)) {
 		pr_err("xdev 0x%p, FMAP prog done, can not modify timer count\n",
 						xdev);
 		return rv;
@@ -490,7 +490,7 @@ int qdma_set_cnt_thresh(unsigned long dev_hndl, unsigned int *cnt_th)
 	/** If qdma_get_active_queue_count() > 0,
 	 *  cnt_th is not allowed to change.
 	 */
-	if (qdma_get_active_queue_count(xdev->conf.pdev->bus->number)) {
+	if (qdma_get_active_queue_count(xdev->dma_device_index)) {
 		pr_err("xdev 0x%p, FMAP prog done, can not modify threshold count\n",
 						xdev);
 		return rv;
@@ -561,6 +561,7 @@ unsigned int qdma_get_cnt_thresh(unsigned long dev_hndl, u32 *cnt_th)
 int qdma_set_cmpl_status_acc(unsigned long dev_hndl, u32 cmpl_status_acc)
 {
 	struct xlnx_dma_dev *xdev = (struct xlnx_dma_dev *)dev_hndl;
+	enum qdma_wrb_interval wb_intvl = (enum qdma_wrb_interval)cmpl_status_acc;
 	int rv = 0;
 
 	/**
@@ -574,15 +575,15 @@ int qdma_set_cmpl_status_acc(unsigned long dev_hndl, u32 cmpl_status_acc)
 	/** If qdma_get_active_queue_count() > 0,
 	 *  cmpl_status_acc is not allowed to change.
 	 */
-	if (qdma_get_active_queue_count(xdev->conf.pdev->bus->number)) {
+	if (qdma_get_active_queue_count(xdev->dma_device_index)) {
 		pr_err("xdev 0x%p, FMAP prog done, cannot modify cmpt acc\n",
 				xdev);
 		return -EINVAL;
 	}
 	/**
-	 * Write the given cmpl_status_acc value to the register
+	 * Write the given cmpl_status_acc (as wb_intvl) value to the register
 	 */
-	rv = xdev->hw.qdma_global_writeback_interval_conf(xdev, cmpl_status_acc,
+	rv = xdev->hw.qdma_global_writeback_interval_conf(xdev, &wb_intvl,
 							QDMA_HW_ACCESS_WRITE);
 	if (unlikely(rv < 0)) {
 		pr_err("set global writeback intvl failed, err = %d", rv);

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_cpm5_access/eqdma_cpm5_access.c
@@ -6622,6 +6622,7 @@ static int eqdma_cpm5_global_writeback_interval_write(void *dev_hndl,
 	if (dev_cap.st_en || dev_cap.mm_cmpt_en) {
 		reg_val = qdma_reg_read(dev_hndl,
 				EQDMA_CPM5_GLBL_DSC_CFG_ADDR);
+		reg_val &= ~GLBL_DSC_CFG_WB_ACC_INT_MASK;
 		reg_val |= FIELD_SET(GLBL_DSC_CFG_WB_ACC_INT_MASK, wb_int);
 		qdma_reg_write(dev_hndl, EQDMA_CPM5_GLBL_DSC_CFG_ADDR,
 				reg_val);

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_soft_access/eqdma_soft_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/eqdma_soft_access/eqdma_soft_access.c
@@ -6575,6 +6575,7 @@ static int eqdma_global_writeback_interval_write(void *dev_hndl,
 
 	if (dev_cap.st_en || dev_cap.mm_cmpt_en) {
 		reg_val = qdma_reg_read(dev_hndl, EQDMA_GLBL_DSC_CFG_ADDR);
+		reg_val &= ~GLBL_DSC_CFG_WB_ACC_INT_MASK;
 		reg_val |= FIELD_SET(GLBL_DSC_CFG_WB_ACC_INT_MASK, wb_int);
 		qdma_reg_write(dev_hndl, EQDMA_GLBL_DSC_CFG_ADDR, reg_val);
 	} else {

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_cpm4_access/qdma_cpm4_access.c
@@ -5797,6 +5797,7 @@ static int qdma_cpm4_global_writeback_interval_write(void *dev_hndl,
 	if (dev_cap.st_en || dev_cap.mm_cmpt_en) {
 		reg_val = qdma_reg_read(dev_hndl,
 				QDMA_CPM4_GLBL_DSC_CFG_ADDR);
+		reg_val &= ~GLBL_DSC_CFG_WB_ACC_INT_MASK;
 		reg_val |= FIELD_SET(GLBL_DSC_CFG_WB_ACC_INT_MASK, wb_int);
 
 		qdma_reg_write(dev_hndl,

--- a/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_access/qdma_soft_access/qdma_soft_access.c
@@ -5980,6 +5980,7 @@ static int qdma_global_writeback_interval_write(void *dev_hndl,
 
 	if (dev_cap.st_en || dev_cap.mm_cmpt_en) {
 		reg_val = qdma_reg_read(dev_hndl, QDMA_OFFSET_GLBL_DSC_CFG);
+		reg_val &= ~QDMA_GLBL_DSC_CFG_WB_ACC_INT_MASK;
 		reg_val |= FIELD_SET(QDMA_GLBL_DSC_CFG_WB_ACC_INT_MASK, wb_int);
 
 		qdma_reg_write(dev_hndl, QDMA_OFFSET_GLBL_DSC_CFG, reg_val);

--- a/QDMA/linux-kernel/driver/libqdma/qdma_regs.c
+++ b/QDMA/linux-kernel/driver/libqdma/qdma_regs.c
@@ -293,6 +293,7 @@ int qdma_global_csr_set(unsigned long dev_hndl, u8 index, u8 count,
 {
 	int rv = 0;
 	struct xlnx_dma_dev *xdev = (struct xlnx_dma_dev *)dev_hndl;
+	enum qdma_wrb_interval wb_intvl = (enum qdma_wrb_interval)csr->wb_intvl;
 
 	if (xdev_check_hndl(__func__, xdev->conf.pdev, dev_hndl) < 0)
 		return -EINVAL;
@@ -305,7 +306,7 @@ int qdma_global_csr_set(unsigned long dev_hndl, u8 index, u8 count,
 				xdev->mod_name);
 		return -EINVAL;
 	}
-	if (xdev->hw.qdma_global_writeback_interval_conf(xdev, csr->wb_intvl,
+	if (xdev->hw.qdma_global_writeback_interval_conf(xdev, &wb_intvl,
 							 QDMA_HW_ACCESS_WRITE))
 		return -EINVAL;
 	if (xdev->hw.qdma_global_csr_conf(xdev, index, count, csr->ring_sz,


### PR DESCRIPTION
## Summary

Fix four defects in libqdma's mutable global-CSR paths:

- pass valid pointers to the writeback-interval hardware callback;
- use libqdma's DMA device index when checking for active queues;
- replace, rather than accumulate, the writeback-interval register field.

These paths are compiled when `QDMA_CSR_REG_UPDATE` is enabled.

For the runtime tests below, we use the following variables:

```bash
BDF="<PCI_BDF>"
DEV="<QDMA_DEVICE_NAME>"
ATTR="/sys/bus/pci/devices/$BDF/qdma"
DMA_CTL="apps/dma-ctl/dma-ctl"
```

## Bug: invalid callback argument in `qdma_global_csr_set()`

`qdma_global_csr_set()` passes `csr->wb_intvl`, an `unsigned int`, directly to a callback expecting:

```c
enum qdma_wrb_interval *wb_int
```

The hardware implementations dereference this argument. Toolchains which diagnose integer-to-pointer conversions as errors reject the code. Builds which permit the conversion can interpret an encoded value such as `7` as address `0x7`, likely causing a kernel panic.

### Reproduction

Enable the mutable CSR paths and build the PF driver:

```bash
make driver MODULE=mod_pf \
  CPPFLAGS="-DQDMA_CSR_REG_UPDATE" \
  KDIR="/lib/modules/$(uname -r)/build"
```

Observe:

```text
error: passing argument 2 of
‘xdev->hw.qdma_global_writeback_interval_conf’ makes pointer from integer
without a cast [-Werror=int-conversion]

note: expected ‘enum qdma_wrb_interval *’ but argument is of type
‘unsigned int’
```

### Fix

Copy the encoded value into a local `enum qdma_wrb_interval` and pass its address:

```c
enum qdma_wrb_interval wb_intvl =
		(enum qdma_wrb_interval)csr->wb_intvl;

xdev->hw.qdma_global_writeback_interval_conf(
		xdev, &wb_intvl, QDMA_HW_ACCESS_WRITE);
```

### Validation

Rebuild after applying this fix:

```bash
make driver MODULE=mod_pf \
  CPPFLAGS="-DQDMA_CSR_REG_UPDATE \
            -Wno-missing-prototypes \
            -Wno-missing-declarations" \
  KDIR="/lib/modules/$(uname -r)/build"
```

Observe that `qdma_regs.o` compiles successfully:

```text
CC [M]  .../libqdma/qdma_regs.o
```

The warning suppressions cover a separate existing issue: `qdma_global_csr_set()` has no header declaration.

## Bug: invalid callback argument in `qdma_set_cmpl_status_acc()`

`qdma_set_cmpl_status_acc()` accepts the encoded writeback interval as a `u32` but passes it directly to the same pointer-taking hardware callback.

### Reproduction

After correcting the preceding `qdma_global_csr_set()` error, build again:

```bash
make driver MODULE=mod_pf \
  CPPFLAGS="-DQDMA_CSR_REG_UPDATE \
            -Wno-missing-prototypes \
            -Wno-missing-declarations" \
  KDIR="/lib/modules/$(uname -r)/build"
```

Observe the independent error in `libqdma_config.c`:

```text
error: passing argument 2 of
‘xdev->hw.qdma_global_writeback_interval_conf’ makes pointer from integer
without a cast [-Werror=int-conversion]

note: expected ‘enum qdma_wrb_interval *’ but argument is of type
‘u32’ {aka ‘unsigned int’}
```

### Fix

Copy the encoded value into a local `enum qdma_wrb_interval` and pass its address:

```c
enum qdma_wrb_interval wb_intvl =
		(enum qdma_wrb_interval)cmpl_status_acc;

xdev->hw.qdma_global_writeback_interval_conf(
		xdev, &wb_intvl, QDMA_HW_ACCESS_WRITE);
```

### Validation

Build with both pointer corrections:

```bash
make driver MODULE=mod_pf \
  CPPFLAGS="-DQDMA_CSR_REG_UPDATE \
            -Wno-missing-prototypes \
            -Wno-missing-declarations" \
  KDIR="/lib/modules/$(uname -r)/build"
```

Observe a successful module link:

```text
LD [M]  .../qdma-pf.ko
```

## Bug: active queues are queried with the PCI bus number

Six runtime setters call:

```c
qdma_get_active_queue_count(xdev->conf.pdev->bus->number)
```

The resource manager is keyed by `xdev->dma_device_index`, not by PCI bus number. The lookup can therefore miss an active resource entry and allow a global CSR update while queues are active.

The affected setters configure:

- interrupt aggregation ring size;
- C2H buffer sizes;
- global descriptor ring sizes;
- C2H timer counters;
- C2H counter thresholds;
- writeback accumulation interval.

### Reproduction

Configure queue capacity and add an MM H2C queue:

```bash
echo 4 | sudo tee "$ATTR/qmax"
sudo "$DMA_CTL" "$DEV" q add idx 0 mode mm dir h2c
```

Observe:

```text
<device>-MM-0 H2C added.
Added 1 Queues.
```

Adding the queue increments libqdma's active-queue count; the queue does not need to be started.

Attempt to update the global ring-size CSR:

```bash
echo "2047 2047 2047 2047 2047 2047 2047 2047 \
2047 2047 2047 2047 2047 2047 2047 2047" \
  | sudo tee "$ATTR/glbl_rng_sz" >/dev/null
echo $?
```

Observe that the affected driver incorrectly accepts the write:

```text
0
```

Remove the queue:

```bash
sudo "$DMA_CTL" "$DEV" q del idx 0 dir h2c
```

### Fix

Use libqdma's internal resource-manager index in all six setters:

```c
qdma_get_active_queue_count(xdev->dma_device_index)
```

This matches the existing global-CSR get and set paths.

### Validation

Add an MM H2C queue and repeat the global ring-size write:

```bash
echo 4 | sudo tee "$ATTR/qmax"
sudo "$DMA_CTL" "$DEV" q add idx 0 mode mm dir h2c

echo "2047 2047 2047 2047 2047 2047 2047 2047 \
2047 2047 2047 2047 2047 2047 2047 2047" \
  | sudo tee "$ATTR/glbl_rng_sz" >/dev/null
```

Observe that the fixed driver rejects the update:

```text
tee: .../glbl_rng_sz: Operation not permitted
```

Remove the queue:

```bash
sudo "$DMA_CTL" "$DEV" q del idx 0 dir h2c
```

## Bug: writeback interval is ORed into the existing field

All four hardware-access implementations update the interval with:

```c
reg_val |= FIELD_SET(GLBL_DSC_CFG_WB_ACC_INT_MASK, wb_int);
```

The previous field is not cleared. Transitions which need a bit to change from one to zero therefore do not take effect. For example, changing the encoded interval from `7` (`0b111`) to `6` (`0b110`) leaves the field at `7`.

The affected implementations are:

- CPM5 enhanced QDMA;
- enhanced soft QDMA;
- CPM4 QDMA;
- soft QDMA.

### Reproduction

Write encoded interval `7`, then encoded interval `6`:

```bash
echo 7 | sudo tee "$ATTR/cmpl_status_acc" >/dev/null
cat "$ATTR/cmpl_status_acc"

echo 6 | sudo tee "$ATTR/cmpl_status_acc" >/dev/null
cat "$ATTR/cmpl_status_acc"
```

Observe that the affected driver remains at `7`:

```text
7
7
```

### Fix

Clear the interval field before setting its new value:

```c
reg_val &= ~GLBL_DSC_CFG_WB_ACC_INT_MASK;
reg_val |= FIELD_SET(GLBL_DSC_CFG_WB_ACC_INT_MASK, wb_int);
```

Apply the equivalent operation in the CPM5 enhanced, enhanced-soft, CPM4, and soft-QDMA backends. The soft-QDMA backend uses its prefixed mask. This read-modify-write sequence preserves the surrounding register bits.

### Validation

Repeat the descending writeback-interval transition:

```bash
echo 7 | sudo tee "$ATTR/cmpl_status_acc" >/dev/null
cat "$ATTR/cmpl_status_acc"

echo 6 | sudo tee "$ATTR/cmpl_status_acc" >/dev/null
cat "$ATTR/cmpl_status_acc"
```

Observe that the fixed driver reports the requested values:

```text
7
6
```
